### PR TITLE
Fix maybe-uninitialized error during compilation with gcc v9.3.0

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -16,7 +16,7 @@ N  0  0  0  0 0
 */
 
 int get_sub_score(char a, char b){
-  int i,j;
+  int i = 4, j = 4;
   switch(a){
   case 'A':
     i = 0;

--- a/src/suffix_tree.cpp
+++ b/src/suffix_tree.cpp
@@ -209,7 +209,7 @@ suffix_node* build_suffix_tree(std::string s){
 }
 
 std::string get_reverse_complement(std::string rev_read){
-  char t;
+  char t = 'N';
   for(unsigned int i = 0;i< rev_read.length();i++){
     switch(rev_read[i]){
     case 'A':

--- a/src/trim_primer_quality.cpp
+++ b/src/trim_primer_quality.cpp
@@ -357,7 +357,7 @@ int trim_bam_qual_primer(std::string bam, std::string bed, std::string bam_out, 
     return -1;
   }
   // Get relevant region
-  int region_id;
+  int region_id = -1;
   uint64_t unmapped, mapped, log_skip;
   std::cout << std::endl << "Number of references in file: " << header->n_targets << std::endl;
   for (int i = 0; i < header->n_targets; ++i){


### PR DESCRIPTION
Initialized variables with default values to resolve `maybe-uninitialized` errors during compilation with gcc v9.3.0.

Example error output:
```
trim_primer_quality.cpp: In function ‘int trim_bam_qual_primer(std::string, std::string, std::string, std:
:string, uint8_t, uint8_t, std::string, bool, int)’:
trim_primer_quality.cpp:375:19: error: ‘region_id’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  375 |   hts_idx_get_stat(idx, region_id, &mapped, &unmapped);
      |   ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```