### PR TITLE
variants example documentation inconsistency

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -115,7 +115,7 @@ Output Options   Description
 
 Example Usage:
 ```
-samtools mpileup -A -d 600000 -B -Q 0 test.trimmed.bam | ivar variants -p test -q 20 -t 0.03 -r test_reference.fa -g test.gff
+samtools mpileup -aa -A -d 600000 -B -Q 0 test.trimmed.bam | ivar variants -p test -q 20 -t 0.03 -r test_reference.fa -g test.gff
 ```
 
 The command above will generate a test.tsv file.


### PR DESCRIPTION
Fixed inconsistency between the flags used with `samtools mpileup` in
the documentation examples for `ivar variants`.

Namely, including the `-aa` flag in both.

Has led to accidental omission of this flag in some [workflow implementations](https://github.com/jaleezyy/covid-19-signal/issues/82)