### PR TITLE
trim options for reanalysis

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -51,6 +51,8 @@ Input Options    Description
            -q    Minimum quality threshold for sliding window to pass (Default: 20)
            -s    Width of sliding window (Default: 4)
            -e    Include reads with no primers. By default, reads with no primers are excluded
+           -k    Keep reads to allow for reanalysis: keep reads which would be dropped by
+                 alignment length filter or primer requirements, but mark them QCFAIL
 
 Output Options   Description
            -p    (Required) Prefix for the output BAM file

--- a/src/ivar.cpp
+++ b/src/ivar.cpp
@@ -39,8 +39,8 @@ struct args_t {
   std::string primer_pair_file;	// -f
   std::string file_list;		// -f
   bool write_no_primers_flag;	// -e
-  bool mark_qcfail_flag;    // -f
   std::string gff;		// -g
+  bool keep_for_reanalysis;     // -k
 } g_args;
 
 void print_usage(){
@@ -69,7 +69,8 @@ void print_trim_usage(){
     "           -q    Minimum quality threshold for sliding window to pass (Default: 20)\n"
     "           -s    Width of sliding window (Default: 4)\n"
     "           -e    Include reads with no primers. By default, reads with no primers are excluded\n"
-    "           -f    Mark reads as QCFAIL instead of excluding them\n\n"
+    "           -k    keep reads to allow for reanalysis: keep reads which would be dropped by\n"
+    "                 alignment length filter or primer requirements, but mark them QCFAIL\n\n"
     "Output Options   Description\n"
     "           -p    (Required) Prefix for the output BAM file\n";
 }
@@ -162,7 +163,7 @@ void print_version_info(){
     "\nPlease raise issues and bug reports at https://github.com/andersen-lab/ivar/\n\n";
 }
 
-static const char *trim_opt_str = "i:b:p:m:q:s:efh?";
+static const char *trim_opt_str = "i:b:p:m:q:s:ekh?";
 static const char *variants_opt_str = "p:t:q:m:r:g:h?";
 static const char *consensus_opt_str = "i:p:q:t:m:n:kh?";
 static const char *removereads_opt_str = "i:p:t:b:h?";
@@ -214,7 +215,7 @@ int main(int argc, char* argv[]){
     g_args.sliding_window = 4;
     g_args.min_length = 30;
     g_args.write_no_primers_flag = false;
-    g_args.mark_qcfail_flag = false;
+    g_args.keep_for_reanalysis = false;
     g_args.bed = "";
     opt = getopt( argc, argv, trim_opt_str);
     while( opt != -1 ) {
@@ -240,8 +241,8 @@ int main(int argc, char* argv[]){
       case 'e':
 	g_args.write_no_primers_flag = true;
 	break;
-      case 'f':
-        g_args.mark_qcfail_flag = true;
+      case 'k':
+        g_args.keep_for_reanalysis = true;
         break;
       case 'h':
       case '?':
@@ -256,7 +257,7 @@ int main(int argc, char* argv[]){
       return -1;
     }
     g_args.prefix = get_filename_without_extension(g_args.prefix,".bam");
-    res = trim_bam_qual_primer(g_args.bam, g_args.bed, g_args.prefix, g_args.region, g_args.min_qual, g_args.sliding_window, cl_cmd.str(), g_args.write_no_primers_flag, g_args.mark_qcfail_flag, g_args.min_length);
+    res = trim_bam_qual_primer(g_args.bam, g_args.bed, g_args.prefix, g_args.region, g_args.min_qual, g_args.sliding_window, cl_cmd.str(), g_args.write_no_primers_flag, g_args.keep_for_reanalysis, g_args.min_length);
   } else if (cmd.compare("variants") == 0){
     g_args.min_qual = 20;
     g_args.min_threshold = 0.03;

--- a/src/ivar.cpp
+++ b/src/ivar.cpp
@@ -69,7 +69,7 @@ void print_trim_usage(){
     "           -q    Minimum quality threshold for sliding window to pass (Default: 20)\n"
     "           -s    Width of sliding window (Default: 4)\n"
     "           -e    Include reads with no primers. By default, reads with no primers are excluded\n"
-    "           -k    keep reads to allow for reanalysis: keep reads which would be dropped by\n"
+    "           -k    Keep reads to allow for reanalysis: keep reads which would be dropped by\n"
     "                 alignment length filter or primer requirements, but mark them QCFAIL\n\n"
     "Output Options   Description\n"
     "           -p    (Required) Prefix for the output BAM file\n";

--- a/tests/test_trim.cpp
+++ b/tests/test_trim.cpp
@@ -7,9 +7,10 @@ typedef struct {
   uint16_t flag;
   uint32_t n_cigar;
   hts_pos_t isize;
+  uint8_t fail;
 } result_t;
 
-int test_trim(uint8_t min_qual, uint8_t sliding_window, bool no_write_flag, bool mark_qcfail_flag, int min_length, std::string testname, int nexpected, result_t *expected)
+int test_trim(uint8_t min_qual, uint8_t sliding_window, bool no_write_flag, bool keep_for_reanalysis, int min_length, std::string testname, int nexpected, result_t *expected)
 {
   int success = 0;
   int res;
@@ -24,28 +25,36 @@ int test_trim(uint8_t min_qual, uint8_t sliding_window, bool no_write_flag, bool
   std::string region_ = "";
   std::string cmd = "@PG\tID:ivar-trim\tPN:ivar\tVN:1.0.0\tCL:ivar trim\n";
 
-  // Test with default paramaters
-  res = trim_bam_qual_primer(bam, bed, prefix, region_, min_qual, sliding_window, cmd, no_write_flag, mark_qcfail_flag, min_length);
+  // Test and check result
+  res = trim_bam_qual_primer(bam, bed, prefix, region_, min_qual, sliding_window, cmd, no_write_flag, keep_for_reanalysis, min_length);
   if (res) {
     success = -1;
-    std::cerr << "default paramater test failed: trim_bam_qual_primer() returned " << res << std::endl;
+    std::cerr << testname << " failed: trim_bam_qual_primer() returned " << res << std::endl;
   } else {
     samFile *in = hts_open(bam_out.c_str(), "r");
     if (!in) {
       success = -1;
-      std::cerr << "default paramater test failed: Can't open " << bam_out << std::endl;
+      std::cerr << testname << " failed: Can't open " << bam_out << std::endl;
     } else {
       sam_hdr_t *hdr = sam_hdr_read(in);
       if (!hdr) {
         success = -1;
-        std::cerr << "default paramater test failed: Can't read header from " << bam_out << std::endl;
+        std::cerr << testname << " failed: Can't read header from " << bam_out << std::endl;
       } else {
         int n = 0;
         while (sam_read1(in, hdr, aln) >= 0) {
+          std::cerr << (aln->core.flag & BAM_FQCFAIL ? "FAIL" : "Pass") << "\t";
 std::cerr << aln->core.n_cigar << "\t" << aln->core.l_qseq << "\t" << aln->core.mtid << "\t" << aln->core.mpos << "\t" << aln->core.isize << std::endl;
           if (aln->core.isize != expected[n].isize) {
             success = -1;
             std::cerr << testname << " test failed: found isize " << aln->core.isize << " at record " << n << ": expected " << expected[n].isize << std::endl;
+          }
+          if (!(aln->core.flag & BAM_FQCFAIL) != !expected[n].fail) {
+            success = -1;
+            std::cerr << testname << " test failed: found " 
+                      << (aln->core.flag & BAM_FQCFAIL ? "FAIL" : "Pass")
+                      << " at record " << n << ": expected "
+                      << (expected[n].fail ? "FAIL" : "Pass") << std::endl;
           }
           n++;
         }
@@ -66,26 +75,26 @@ int main() {
 
   // Default paramaters
   {
-    result_t expected[5] = { { 163, 2, 364 }, {163, 2, 382 }, {83, 2, -356}, {83, 2, -382}, {67, 2, -398} };
+    result_t expected[5] = { { 163, 2, 364, 0}, {163, 2, 382, 0}, {83, 2, -356, 0}, {83, 2, -382, 0}, {67, 2, -398, 0} };
     if (test_trim(20, 4, false, false, 30, "default paramaters", 5, expected)) success = -1;
   }
 
   // -e (write missing primers)
   {
-    result_t expected[9] = { {131, 7, 403}, { 163, 2, 364 }, {163, 2, 382 }, {163, 2, 242}, {83, 2, -242}, {147, 2, -150}, {83, 2, -356}, {83, 2, -382}, {67, 2, -398} };
+    result_t expected[9] = { {131, 7, 403, 0}, { 163, 2, 364, 0}, {163, 2, 382, 0}, {163, 2, 242, 0}, {83, 2, -242, 0}, {147, 2, -150, 0}, {83, 2, -356, 0}, {83, 2, -382, 0}, {67, 2, -398, 0} };
     if (test_trim(20, 4, true, false, 30, "write missing primers", 9, expected)) success = -1;
   }
 
-  // -f (mark quality trimmed as failed)
+  // -k (keep for reanalysis)
   {
-    result_t expected[6] = { { 163, 2, 364 }, {163, 2, 382 }, {611, 2, -150}, {83, 2, -356}, {83, 2, -382}, {67, 2, -398} };
-    if (test_trim(20, 4, false, true, 30, "default paramaters", 6, expected)) success = -1;
+    result_t expected[10] = { {643, 7, 403, 1}, { 163, 2, 364, 0}, {163, 2, 382, 0}, {675, 2, 242,1}, {595, 2, -242, 1}, {611, 2, -150, 1}, {659, 2, -150, 1}, {83, 2, -356, 0}, {83, 2, -382, 0}, {67, 2, -398, 0} };
+    if (test_trim(20, 4, false, true, 30, "keep for reanalysis", 10, expected)) success = -1;
   }
 
-  // -e -f (write everything)
+  // -e -k (all flags)
   {
-    result_t expected[10] = { {643, 7, 403}, { 163, 2, 364 }, {163, 2, 382 }, {675, 2, 242}, {595, 2, -242}, {611, 2, -150}, {659, 2, -150}, {83, 2, -356}, {83, 2, -382}, {67, 2, -398} };
-    if (test_trim(20, 4, true, true, 30, "write everything", 10, expected)) success = -1;
+    result_t expected[10] = { {643, 7, 403, 0}, { 163, 2, 364, 0}, {163, 2, 382, 0}, {675, 2, 242,0}, {595, 2, -242,0}, {611, 2, -150, 1}, {659, 2, -150, 0}, {83, 2, -356, 0}, {83, 2, -382, 0}, {67, 2, -398, 0} };
+    if (test_trim(20, 4, true, true, 30, "both flags", 10, expected)) success = -1;
   }
 
   return success;


### PR DESCRIPTION
This pull request supersedes #55 (add -f flag). It replaces -f with -k and changes the behaviour slightly.

After using the new release with the -f flag for a little while, it has become clear that the behaviour is still not quite what we need, and probably not quite as useful to other people as we had hoped. This PR addresses these problems.

I am reluctant to create a pull request that is not backward compatible, but in this case I think it is justified because the -f flag is so new, only being added at the previous release, and because I strongly suspect that nobody but us at the Sanger Institute is using it yet.

This PR does *not* change the behaviour of ivar trim when the -f option is not given.

With this PR, the behaviour is now:

```
option | Read too small         | Primer not found

none    | NOT copied             | NOT copied
-e       | NOT copied             | copied
-k       | copied (and failed) | copied (and failed)
-ek     | copied (and failed) | copied
```

Our hope is that this change will not just benefit us, but be generally useful to others.
