### PR TITLE
Cleanup Codebase

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -15,109 +15,123 @@ C -1 -1 -1  1 0
 N  0  0  0  0 0
 */
 
-int get_sub_score(char a, char b){
+int get_sub_score(char a, char b) {
   int i = 4, j = 4;
-  switch(a){
-  case 'A':
-    i = 0;
-    break;
-  case 'T':
-    i = 1;
-    break;
-  case 'G':
-    i = 2;
-    break;
-  case 'C':
-    i = 3;
-    break;
-  case 'N':
-    i = 4;
-    break;
+
+  switch(a) {
+    case 'A':
+      i = 0;
+      break;
+    case 'T':
+      i = 1;
+      break;
+    case 'G':
+      i = 2;
+      break;
+    case 'C':
+      i = 3;
+      break;
+    case 'N':
+      i = 4;
+      break;
   }
-  switch(b){
-  case 'A':
-    j = 0;
-    break;
-  case 'T':
-    j = 1;
-    break;
-  case 'G':
-    j = 2;
-    break;
-  case 'C':
-    j = 3;
-    break;
-  case 'N':
-    j = 4;
-    break;
+  switch(b) {
+    case 'A':
+      j = 0;
+      break;
+    case 'T':
+      j = 1;
+      break;
+    case 'G':
+      j = 2;
+      break;
+    case 'C':
+      j = 3;
+      break;
+    case 'N':
+      j = 4;
+      break;
   }
+
   return substitution[i][j];
 }
 
-int get_gap_penalty(int k, char a){
-  if(a == 'N')			// Allow for i7 and i5 indexesto be specified as NNNNNNNN
+int get_gap_penalty(int k, char a) {
+  if (a == 'N')			// Allow for i7 and i5 indexesto be specified as NNNNNNNN
     return 0;
+
   return k * gap_open; // Linear Gap Penalty
 }
 
-void print_matrix(int h[][max_adapter_size], int r, int c, std::string read, std::string adap){
-  for(int i =0; i< r;i++){
-    if(i == 0){
+void print_matrix(int h[][max_adapter_size], int r, int c, std::string read, std::string adap) {
+  for (int i =0; i< r;i++) {
+    if (i == 0) {
       std::cout << "    ";
-      for(int k =0; k < c-1; k++) std::cout << adap[k] << " ";
+      for (int k =0; k < c-1; k++) std::cout << adap[k] << " ";
       std::cout << "\n";
     }
-    for(int j = 0; j < c;j++){
-      if(j == 0 && i > 0){
-	if(i -1 < (int)read.length())
-	  std::cout << read[i-1] << " ";
+
+    for (int j = 0; j < c;j++) {
+      if (j == 0 && i > 0) {
+        if (i -1 < (int)read.length())
+          std::cout << read[i-1] << " ";
       }
-      if(i == 0 && j == 0)
-	std::cout << " " << " ";
+
+      if (i == 0 && j == 0)
+        std::cout << " " << " ";
+
       std::cout << h[i][j] << " ";
     }
+
     std::cout << "\n";
   }
 }
 
 // Return Value 1 - Diag, 2->Right, 3->Down, 0-> 0
-int*  get_score_cell(int h[][max_adapter_size], int i, int j, std::string read, std::string adap){
+int*  get_score_cell(int h[][max_adapter_size], int i, int j, std::string read, std::string adap) {
   int s[] = {0,0,0};
   int *tmp = new int[2];
+
   tmp[0] = 0;
   tmp[1] = 0;
+
   s[0] = h[i-1][j-1] + get_sub_score(read[i-1], adap[j-1]);
   s[1] = h[i-1][j] - get_gap_penalty(1, adap[j-1]);
   s[2] = h[i][j-1] - get_gap_penalty(1, read[i-1]);
+
   int max = (s[0]>=s[1]) ? s[0] : s[1];
   max = (max>=s[2]) ? max : s[2];
   max = (max > 0) ? max : 0;
   tmp[0] = max;
-  if(max == s[0]){
+
+  if (max == s[0]) {
     tmp[1] = 1;
-  } else if(max == s[1]){
+  } else if (max == s[1]) {
     tmp[1] = 3;
-  } else if(max == s[2]){
+  } else if (max == s[2]) {
     tmp[1] = 2;
   }
+
   return tmp;
 }
 
-void print_alignment(char a[2][max_read_size], int n){
+void print_alignment(char a[2][max_read_size], int n) {
   std::cout << "Alignment: " << std::endl << std::endl;
-  for(int j =0;j<2;j++){
-    if(j == 0)
+
+  for (int j =0;j<2;j++) {
+    if (j == 0)
       std::cout << "Read: ";
-    else if(j == 1)
+    else if (j == 1)
       std::cout << "Adap: ";
-    for(int i = n -1; i >= 0;i--){
+    for (int i = n -1; i >= 0;i--) {
       std::cout << a[j][i] << " ";
     }
+
     std::cout << std::endl;
   }
 }
 
-int* align_seqs(std::string read, std::string adap){
+int* align_seqs(std::string read, std::string adap) {
   int h[max_read_size][max_adapter_size],
     t[max_read_size][max_adapter_size],
     m = read.length() + 1,
@@ -128,27 +142,33 @@ int* align_seqs(std::string read, std::string adap){
     max_score,
     *rt = new int[2],
     *tmp = new int[2];
+
   rt[0] = -1;
   rt[1] = read.length();
+
   // Initialize first column to 0
-  for(int i = 0; i < n; i++) h[0][i] = 0;
+  for (int i = 0; i < n; i++) h[0][i] = 0;
+
   // Initialize first row to 0
-  for(int i = 0; i < m; i++) h[i][0] = 0;
+  for (int i = 0; i < m; i++) h[i][0] = 0;
+
   // print_matrix(h, m, n, read, adap);
-  for(int i = 1; i < m; i++){
-    for(int j = 1; j < n; j++){
+  for (int i = 1; i < m; i++) {
+    for (int j = 1; j < n; j++) {
       tmp = get_score_cell(h, i, j, read, adap);
       h[i][j] = *tmp;
       t[i][j] = *(tmp+1);
-      if(*tmp >= max_v){
-	max_i = i;
-	max_j = j;
-	max_v = *tmp;
+
+      if (*tmp >= max_v) {
+        max_i = i;
+        max_j = j;
+        max_v = *tmp;
       }
     }
   }
+
   max_score = max_v;
-  // if(max_i != read.length())	// Ensure alignment to end of read.
+  // if (max_i != read.length())	// Ensure alignment to end of read.
   //   return rt;
   // std::cout << "Score: " << max_v << " ";
   // print_matrix(h, m, n, read, adap);
@@ -156,69 +176,76 @@ int* align_seqs(std::string read, std::string adap){
   // Traceback
   int _t, _l, _d, _align_n = 0;
   char _align[2][max_read_size];
+
   // 1 - Diag, 2->Right, 3->Down
-  while(max_v != 0){
+  while (max_v != 0) {
     _d = h[max_i-1][max_j-1];
     _l = h[max_i][max_j-1];
     _t = h[max_i-1][max_j];
-    switch(t[max_i][max_j]){
-    case 1:
-      max_v = _d;
-      max_i = max_i -1;
-      max_j = max_j - 1;
-      _align[0][_align_n] = read[max_i];
-      _align[1][_align_n] = adap[max_j];
-      _align_n++;
-      break;
-    case 2:
-      max_v = _l;
-      max_j = max_j - 1;
-      _align[0][_align_n] = '-';
-      _align[1][_align_n] = adap[max_j];
-      _align_n++;
-      break;
-    case 3:
-      max_v = _t;
-      max_i = max_i - 1;
-      _align[0][_align_n] = read[max_i];
-      _align[1][_align_n] = '-';
-      _align_n++;
-      break;
-    case 0:
-      max_v = 0;
-      break;
+
+    switch(t[max_i][max_j]) {
+      case 1:
+        max_v = _d;
+        max_i = max_i -1;
+        max_j = max_j - 1;
+        _align[0][_align_n] = read[max_i];
+        _align[1][_align_n] = adap[max_j];
+        _align_n++;
+        break;
+      case 2:
+        max_v = _l;
+        max_j = max_j - 1;
+        _align[0][_align_n] = '-';
+        _align[1][_align_n] = adap[max_j];
+        _align_n++;
+        break;
+      case 3:
+        max_v = _t;
+        max_i = max_i - 1;
+        _align[0][_align_n] = read[max_i];
+        _align[1][_align_n] = '-';
+        _align_n++;
+        break;
+      case 0:
+        max_v = 0;
+        break;
     }
   }
+
   rt[1] = max_i;
   print_alignment(_align, _align_n);
-  if(max_score <= ((_align_n - 2) * unit_score) - get_gap_penalty(2, 'A') || max_j != 0) // If alignment does not start at beginning of adapter
+
+  if (max_score <= ((_align_n - 2) * unit_score) - get_gap_penalty(2, 'A') || max_j != 0) // If alignment does not start at beginning of adapter
     return rt;
+
   rt[0] = max_score;
+  
   // print_alignment(_align, _align_n);
+
   return rt;
 }
 
-// int find_adapters_contaminants(std::istream &cin, std::string adp_cntms_file){
+// int find_adapters_contaminants(std::istream &cin, std::string adp_cntms_file) {
 //   std::vector<std::string> adp = read_adapters_from_fasta(adp_cntms_file, "Read1");
 //   std::string line, bases, qual, b;
 //   int ctr = 0, score, *t = new int[2];
-//   while (std::getline(cin, line)){
-//     if(ctr % 400000 == 0)
+//   while (std::getline(cin, line)) {
+//     if (ctr % 400000 == 0)
 //       std::cout << "Processed " << (ctr/4) << " reads ..." << std::endl;
-//     if(ctr % 2 == 0){
+//     if (ctr % 2 == 0) {
 //       ctr++;
 //       continue;
 //     }
-//     if((ctr+1) % 2 == 0 && (ctr + 1) % 4 == 0 ){
+//     if ((ctr+1) % 2 == 0 && (ctr + 1) % 4 == 0 ) {
 //       qual = line;
 //       // std::cout << bases << std::endl;
 //       // std::cout << qual << std::endl;
 //       score = -1;
-//       for(std::vector<std::string>::iterator it = adp.begin(); it != adp.end() && score == -1; ++it) {
+//       for (std::vector<std::string>::iterator it = adp.begin(); it != adp.end() && score == -1; ++it) {
 // 	b = ((*it).length() > bases.length()) ? bases : bases.substr(bases.length() - (*it).length(), (*it).length());
 // 	t = align_seqs(b, *it);
 // 	score = *t;
-// 	if(score != -1)
+// 	if (score != -1)
 // 	  std::cout << "Trimmed: " << bases.substr(0, bases.length() - *(t+1)) << std::endl;
 //       }
 //     } else {
@@ -229,7 +256,7 @@ int* align_seqs(std::string read, std::string adap){
 //   return 0;
 // }
 
-// int main(int argc, char* argv[]){
+// int main(int argc, char* argv[]) {
 //   std::string adp = "../data/adapters/NexteraPR.fa";
 //   // clock_t begin = clock();
 //   find_adapters_contaminants(std::cin, adp);

--- a/src/allele_functions.cpp
+++ b/src/allele_functions.cpp
@@ -6,189 +6,222 @@
 
 #include "allele_functions.h"
 
-void print_allele_depths(std::vector<allele> ad){
+void print_allele_depths(std::vector<allele> ad) {
   std::cout << "AD Size: " << ad.size() << " " << std::endl;
-  for(std::vector<allele>::iterator it = ad.begin(); it != ad.end(); ++it) {
+
+  for (std::vector<allele>::iterator it = ad.begin(); it != ad.end(); ++it) {
     std::cout << "Nuc: " << it->nuc << std::endl;;
     std::cout << "Depth: " << it->depth << std::endl;
-      std::cout << "Reverse: " << it->reverse <<std::endl;
+    std::cout << "Reverse: " << it->reverse <<std::endl;
     std::cout << "Qual: " << (uint16_t) it->mean_qual << std::endl;
     std::cout << "Beg: " << it->beg << std::endl;
     std::cout << "End: " << it->end << std::endl;
   }
 }
 
-int check_allele_exists(std::string n, std::vector<allele> ad){
-  for(std::vector<allele>::iterator it = ad.begin(); it != ad.end(); ++it) {
-    if(it->nuc.compare(n) == 0){
+int check_allele_exists(std::string n, std::vector<allele> ad) {
+  for (std::vector<allele>::iterator it = ad.begin(); it != ad.end(); ++it) {
+    if (it->nuc.compare(n) == 0) {
       return it - ad.begin();
     }
   }
+
   return -1;
 }
 
-int find_ref_in_allele(std::vector<allele> ad, char ref){
+int find_ref_in_allele(std::vector<allele> ad, char ref) {
   std::string ref_s(1, ref);
   std::vector<allele>::iterator it = ad.begin();
-  while(it < ad.end()){
-    if(it->nuc.compare(ref_s) == 0)
+
+  while (it < ad.end()) {
+    if (it->nuc.compare(ref_s) == 0)
       return (it - ad.begin());
+
     it++;
   }
+
   return -1;
 }
 
-std::vector<allele> update_allele_depth(char ref,std::string bases, std::string qualities, uint8_t min_qual){
+std::vector<allele> update_allele_depth(char ref,std::string bases, std::string qualities, uint8_t min_qual) {
   std::vector<allele> ad;
   std::string indel;
+
   uint32_t i = 0, n =0, j = 0, q_ind = 0;
+
   bool beg, end;
   uint8_t q;
-  while (i < bases.length()){
+
+  while (i < bases.length()) {
     beg = false;
     end = false;
-    if(bases[i] == '^'){
+
+    if (bases[i] == '^') {
       i += 2;			// Skip mapping quality as well (i+1) - 33
       continue;
     }
-    if(bases[i] == '$'){
+
+    if (bases[i] == '$') {
       i++;
       continue;
     }
+
     q = qualities[q_ind] - 33;
     std::string b;
     allele tmp;
     bool forward= true;
-    switch(bases[i]){
-    case '.':
-      b = ref;
-      end = (bases[i+1] == '$');
-      beg = (bases[i+1] == '^');
-      break;
-    case ',':
-      b = ref;
-      forward = false;
-      end = (bases[i+1] == '$');
-      beg = (bases[i+1] == '^');
-      break;
-    case '*':
-      b = bases[i];
-      break;
-    case '+': case '-':
-      j = i+1;
-      while(isdigit(bases[j])){
-	j++;
-      }
-      j = j - (i+1);
-      n = stoi(bases.substr(i+1, j));
-      indel = bases.substr(i+1+j, n);
-      transform(indel.begin(), indel.end(), indel.begin(),::toupper);
-      b = bases[i] + indel;	// + for Insertion and - for Deletion
-      i += n + j;
-      if(indel[0]>=97 && indel[0] <= 122)
-	forward=false;
-      q = min_qual;		// For insertions and deletion ust use minimum quality.
-      break;
-    default:
-      int asc_val = bases[i];
-      if(asc_val >= 65 && asc_val <= 90){
-	b = bases[i];
-      } else if(bases[i]>=97 && bases[i]<=122){
-	b = bases[i] - ('a' - 'A');
-	forward = false;
-      }
-      end = (bases[i+1] == '$');
-      beg = (bases[i+1] == '^');
+
+    switch(bases[i]) {
+      case '.':
+        b = ref;
+
+        end = (bases[i+1] == '$');
+        beg = (bases[i+1] == '^');
+        break;
+      case ',':
+        b = ref;
+        forward = false;
+
+        end = (bases[i+1] == '$');
+        beg = (bases[i+1] == '^');
+        break;
+      case '*':
+        b = bases[i];
+        break;
+      case '+': case '-':
+        j = i+1;
+
+        while (isdigit(bases[j])) {
+          j++;
+        }
+
+        j = j - (i+1);
+        n = stoi(bases.substr(i+1, j));
+        indel = bases.substr(i+1+j, n);
+        transform(indel.begin(), indel.end(), indel.begin(),::toupper);
+
+        b = bases[i] + indel;	// + for Insertion and - for Deletion
+
+        i += n + j;
+
+        if (indel[0]>=97 && indel[0] <= 122)
+          forward=false;
+
+        q = min_qual;		// For insertions and deletion ust use minimum quality.
+        break;
+      default:
+        int asc_val = bases[i];
+
+        if (asc_val >= 65 && asc_val <= 90) {
+          b = bases[i];
+        } else if (bases[i]>=97 && bases[i]<=122) {
+          b = bases[i] - ('a' - 'A');
+          forward = false;
+        }
+
+        end = (bases[i+1] == '$');
+        beg = (bases[i+1] == '^');
     }
+
     int ind = check_allele_exists(b, ad);
-    if(q >= min_qual){
-      if (ind==-1){
-	tmp.nuc = b;
-	tmp.depth = 1;
-	tmp.tmp_mean_qual = q;
-	if(!forward)
-	  tmp.reverse = 1;
-	else
-	  tmp.reverse = 0;
-	if(beg)
-	  tmp.beg = 1;
-	else
-	  tmp.beg = 0;
-	if(end)
-	  tmp.end = 1;
-	else
-	  tmp.end = 0;
-	ad.push_back(tmp);
+
+    if (q >= min_qual) {
+      if (ind==-1) {
+        tmp.nuc = b;
+        tmp.depth = 1;
+        tmp.tmp_mean_qual = q;
+
+        if (!forward)
+          tmp.reverse = 1;
+        else
+          tmp.reverse = 0;
+        if (beg)
+          tmp.beg = 1;
+        else
+          tmp.beg = 0;
+        if (end)
+          tmp.end = 1;
+        else
+          tmp.end = 0;
+
+        ad.push_back(tmp);
       } else {
-	ad.at(ind).tmp_mean_qual = (ad.at(ind).tmp_mean_qual * ad.at(ind).depth + q)/(ad.at(ind).depth + 1);
-	ad.at(ind).depth += 1;
-	if(beg)
-	  ad.at(ind).beg += 1;
-	if(end)
-	  ad.at(ind).end += 1;
-	if(!forward)
-	  ad.at(ind).reverse += 1;
+        ad.at(ind).tmp_mean_qual = (ad.at(ind).tmp_mean_qual * ad.at(ind).depth + q)/(ad.at(ind).depth + 1);
+        ad.at(ind).depth += 1;
+
+        if (beg)
+          ad.at(ind).beg += 1;
+        if (end)
+          ad.at(ind).end += 1;
+        if (!forward)
+          ad.at(ind).reverse += 1;
       }
     }
+
     i++;
-    if(b[0] !='+' && b[0]!='-')
+
+    if (b[0] !='+' && b[0]!='-')
       q_ind++;
   }
-  for(std::vector<allele>::iterator it = ad.begin(); it!=ad.end(); ++it){
+
+  for (std::vector<allele>::iterator it = ad.begin(); it!=ad.end(); ++it) {
     it->mean_qual = (uint8_t) it->tmp_mean_qual;
   }
-  if(ad.size() > 0)
+
+  if (ad.size() > 0)
     std::sort(ad.begin(), ad.end());
+
   return ad;
 }
 
-int get_index(char a){
-  switch(a){
-  case'Y':
-    a = 0;
-    break;
-  case'R':
-    a = 1;
-    break;
-  case'W':
-    a = 2;
-    break;
-  case'S':
-    a = 3;
-    break;
-  case'K':
-    a = 4;
-    break;
-  case'M':
-    a = 5;
-    break;
-  case'A':
-    a = 6;
-    break;
-  case'T':
-    a = 7;
-    break;
-  case'G':
-    a = 8;
-    break;
-  case'C':
-    a = 9;
-    break;
-  case'D':
-    a = 10;
-    break;
-  case'V':
-    a = 11;
-    break;
-  case'H':
-    a = 12;
-    break;
-  case'B':
-    a = 13;
-    break;
-  default:
-    a = -1;
+int get_index(char a) {
+  switch(a) {
+    case 'Y':
+      a = 0;
+      break;
+    case 'R':
+      a = 1;
+      break;
+    case 'W':
+      a = 2;
+      break;
+    case 'S':
+      a = 3;
+      break;
+    case 'K':
+      a = 4;
+      break;
+    case 'M':
+      a = 5;
+      break;
+    case 'A':
+      a = 6;
+      break;
+    case 'T':
+      a = 7;
+      break;
+    case 'G':
+      a = 8;
+      break;
+    case 'C':
+      a = 9;
+      break;
+    case 'D':
+      a = 10;
+      break;
+    case 'V':
+      a = 11;
+      break;
+    case 'H':
+      a = 12;
+      break;
+    case 'B':
+      a = 13;
+      break;
+    default:
+      a = -1;
   }
+
   return (int) a;
 }
 
@@ -212,9 +245,10 @@ H N H N N H H H N H N N H N
 B N N B B N N B B B N N N B
 
  */
-char gt2iupac(char a, char b){
-  if(a == '*' || b == '*')
+char gt2iupac(char a, char b) {
+  if (a == '*' || b == '*')
     return 'N';
+
   static const char iupac[14][14] = {
     {'Y', 'N', 'H', 'B', 'B', 'H', 'H', 'Y', 'B', 'Y', 'N', 'N', 'H', 'B'},
     {'N', 'R', 'D', 'V', 'D', 'V', 'R', 'D', 'R', 'V', 'D', 'V', 'N', 'N'},
@@ -231,13 +265,17 @@ char gt2iupac(char a, char b){
     {'H', 'N', 'H', 'N', 'N', 'H', 'H', 'H', 'N', 'H', 'N', 'N', 'H', 'N'},
     {'B', 'N', 'N', 'B', 'B', 'N', 'N', 'B', 'B', 'B', 'N', 'N', 'N', 'B'}
   };
+
   if ( a>='a' ) a -= 'a' - 'A';
   if ( b>='a' ) b -= 'a' - 'A';
+
   int _a, _b;
   _a = get_index(a);
   _b = get_index(b);
-  if(_a == -1 || _b == -1)
+
+  if (_a == -1 || _b == -1)
     return 'N';
+
   return iupac[_a][_b];
 }
 
@@ -263,13 +301,15 @@ char gt2iupac(char a, char b){
     ['CCA', 'CCT', 'CCG', 'CCC']]]
  */
 
-char codon2aa(char n1, char n2, char n3){
+char codon2aa(char n1, char n2, char n3) {
   if ( n1>='a' ) n1 -= 'a' - 'A';
   if ( n2>='a' ) n2 -= 'a' - 'A';
   if ( n3>='a' ) n3 -= 'a' - 'A';
+
   int _n1 = get_index(n1),
     _n2 = get_index(n2),
     _n3 = get_index(n3);
+
   static const char iupac_aa[4][4][4] = {
     {
       {'K', 'N', 'K', 'N'},	// 'AAA', 'AAT', 'AAG', 'AAC'
@@ -296,7 +336,9 @@ char codon2aa(char n1, char n2, char n3){
       {'P', 'P', 'P', 'P'}	// 'CCA', 'CCT', 'CCG', 'CCC'
     }
   };
-  if((_n1 < 6) || (_n1 > 9) || (_n2 < 6) || (_n2 > 9) || (_n3 < 6) || (_n3 > 9))
+
+  if ((_n1 < 6) || (_n1 > 9) || (_n2 < 6) || (_n2 > 9) || (_n3 < 6) || (_n3 > 9))
     return 'X';
+    
   return iupac_aa[_n1-6][_n2-6][_n3-6];
 }

--- a/src/allele_functions.h
+++ b/src/allele_functions.h
@@ -13,10 +13,10 @@ struct allele{
   uint32_t beg;
   uint32_t end;
   float tmp_mean_qual;
-  bool operator < (const allele& a) const{
+  bool operator < (const allele& a) const {
     return (nuc.compare(a.nuc) > 0) ? true : false;
   }
-  bool operator == (const allele& a) const{
+  bool operator == (const allele& a) const {
     return (nuc.compare(a.nuc) == 0) ? true : false;
   }
 };

--- a/src/call_consensus.cpp
+++ b/src/call_consensus.cpp
@@ -12,14 +12,14 @@ struct maj {
 #define GET_MAX_INDICES(type_t, pu, no, m) {		\
     type_t v = 1;					\
     type_t *p = (type_t*) (pu);			\
-    for (int k = 0; k < no; ++k){			\
-      if(p[k] > v){					\
-	v = p[k];					\
-	m.n = 0;					\
-	m.ind[m.n] = k;				\
-      } else if(p[k] == v) {				\
-	m.n++;						\
-	m.ind[m.n] = k;				\
+    for (int k = 0; k < no; ++k) {			\
+      if (p[k] > v) {					\
+        v = p[k];					\
+        m.n = 0;					\
+        m.ind[m.n] = k;				\
+      } else if (p[k] == v) {				\
+        m.n++;						\
+        m.ind[m.n] = k;				\
       }						\
     }							\
   }
@@ -32,49 +32,59 @@ struct maj {
 static inline char gt2iupac(char a, char b)
 {
   static const char iupac[4][4] = { {'A','M','R','W'},{'M','C','S','Y'},{'R','S','G','K'},{'W','Y','K','T'} };
+
   if ( a>='a' ) a -= 'a' - 'A';
+
   if ( b>='a' ) b -= 'a' - 'A';
+
   if ( a=='A' ) a = 0;
   else if ( a=='C' ) a = 1;
   else if ( a=='G' ) a = 2;
   else if ( a=='T' ) a = 3;
   else return 'N';
+
   if ( b=='A' ) b = 0;
   else if ( b=='C' ) b = 1;
   else if ( b=='G' ) b = 2;
   else if ( b=='T' ) b = 3;
   else return 'N';
+
   return iupac[(int)a][(int)b];
 }
 
-void get_consensus_indel(char **allele, maj m, char *&nuc){
+void get_consensus_indel(char **allele, maj m, char *&nuc) {
   int max_len = 0, l = 0;
   uint8_t q = 0;
-  for (int k = 0; k <= m.n; ++k){
-    if(strlen(allele[m.ind[k]]) > max_len)
+
+  for (int k = 0; k <= m.n; ++k) {
+    if (strlen(allele[m.ind[k]]) > max_len)
       max_len = strlen(allele[m.ind[k]]);
   }
+
   char n;
-  for (int j = 0; j < max_len; ++j){ // Iterate over base positions
+  for (int j = 0; j < max_len; ++j) { // Iterate over base positions
     n = 0;
-    for (int k = 0; k <= m.n ; ++k){  // Iterate over major alleles
-      if(j < strlen(allele[m.ind[k]])){
-	if(n == 0){
-	  n = allele[m.ind[k]][j];
-	} else {
-	  n = gt2iupac(n, allele[m.ind[k]][j]);
-	}
+    for (int k = 0; k <= m.n ; ++k) {  // Iterate over major alleles
+      if (j < strlen(allele[m.ind[k]])) {
+        if (n == 0) {
+          n = allele[m.ind[k]][j];
+        } else {
+          n = gt2iupac(n, allele[m.ind[k]][j]);
+        }
       }
     }
-    if(n == 0)
+
+    if (n == 0)
       nuc[l] = GAP;
     else
       nuc[l] = n;
+
     l++;
-    if(l % INDEL_SIZE == 0){
+    if (l % INDEL_SIZE == 0) {
       nuc = (char*) realloc(nuc, INDEL_SIZE * ((l/INDEL_SIZE) + 1) * sizeof(char));
     }
   }
+
   nuc[l] = 0;
 }
 
@@ -83,89 +93,110 @@ int main_old(int argc, char* argv[]) {
   std::string bcf = std::string(argv[1]);
   std::string region_;
   std::string out_path = std::string(argv[2]);
-  if(argc > 3) {
+
+  if (argc > 3) {
     region_ = std::string(argv[3]);
   }
-  if(!bcf.empty()) {
+
+  if (!bcf.empty()) {
     //open BCF for reading
     htsFile *in = bcf_open(bcf.c_str(), "r");
     std::ofstream out(out_path.c_str());
     out << ">" << out_path << "\n";
-    if(in == NULL) {
+
+    if (in == NULL) {
       throw std::runtime_error("Unable to open BCF/VCF file.");
     }
+
     int ad_id;
+
     //Get the header
     bcf_hdr_t *header = bcf_hdr_read(in);
-    if(header == NULL) {
+    if (header == NULL) {
       bcf_close(in);
       throw std::runtime_error("Unable to open BCF header.");
     }
+
     ad_id = bcf_hdr_id2int(header, BCF_DT_ID, "AD");
     std::cout << ad_id << " " << std::endl;
+
     //Initialize iterator
     bcf1_t *v = bcf_init();
     int ctr = 0, prev_pos = 0, s, d;
     maj m;
     char *nuc =(char *) malloc(INDEL_SIZE * sizeof(char)), *r;
-    while(bcf_read(in, header, v) ==0){
+
+    while (bcf_read(in, header, v) ==0) {
       // std::cout << "Position: " << v->pos << std::endl;
       // std::cout << "Number of Alleles: " << v->n_allele << std::endl;
-      for (int i = prev_pos; i < v->pos - 1; ++i){
-	out << GAP;
+      for (int i = prev_pos; i < v->pos - 1; ++i) {
+        out << GAP;
       }
+
       bcf_unpack(v, BCF_UN_FMT);
       bcf_unpack(v, BCF_UN_STR);
       bcf_fmt_t *fmt = v->d.fmt;
-      for (int i = 0; i < v->n_fmt; ++i){
-	if(strcmp(header->id[BCF_DT_ID][fmt[i].id].key, "AD") == 0){
-	  m.ind = (int *) malloc(fmt[i].n * sizeof(int));
-	  m.n = -1;
-	  switch(fmt[i].type){
-	  case BCF_BT_INT8: GET_MAX_INDICES(int8_t, fmt[i].p, fmt[i].n, m); break;
-	  case BCF_BT_INT16: GET_MAX_INDICES(int16_t, fmt[i].p, fmt[i].n, m); break;
-	  case BCF_BT_INT32: GET_MAX_INDICES(int32_t, fmt[i].p, fmt[i].n, m); break;
-	  case BCF_BT_FLOAT: GET_MAX_INDICES(float, fmt[i].p, fmt[i].n, m); break;
-	  default: hts_log_error("Unexpected type %d", fmt[i].type); exit(1);
-	  }
-	  if(m.n == -1){
-	    out << GAP;
-	  } else {
-	    if(bcf_get_variant_types(v) == VCF_REF){
-	      out << v->d.allele[0];
-	    } else if(bcf_get_variant_types(v) == VCF_SNP || bcf_get_variant_types(v) == VCF_MNP){
-	      nuc =(char *) malloc(INDEL_SIZE * sizeof(char));
-	      get_consensus_indel(v->d.allele, m, nuc);
-	      out << nuc;
-	    } else {	// For INDEL insert difference.between reference and consensus allele
-	      nuc =(char *) malloc(INDEL_SIZE * sizeof(char));
-	      get_consensus_indel(v->d.allele, m, nuc);
-	      s = strlen(v->d.allele[0]) - strlen(nuc); //  > 0 Deletion. < 0 INSERTION
-	      d = (s > 0) ? strlen(v->d.allele[0]) : strlen(nuc);
-	      r = (s > 0) ? v->d.allele[0] : nuc;
-	      s = (s < 0) ? -1 * s : s;
-	      if(v->pos == 499)
-		std::cout << "Number: " << m.n << " Maj Allele: " << v->d.allele[m.ind[0]] << strlen(nuc) << " - Nuc Length" << nuc << " " << s << " " << d << std::endl;
-	      for (int i = 0; i < s; ++i){
-		out << r[d - s];
-	      }
-	      free(m.ind);
-	      free(nuc);
-	      // std::cout << nuc << std::endl;
-	    }
-	  }
-	}
+
+      for (int i = 0; i < v->n_fmt; ++i) {
+        if (strcmp(header->id[BCF_DT_ID][fmt[i].id].key, "AD") == 0) {
+          m.ind = (int *) malloc(fmt[i].n * sizeof(int));
+          m.n = -1;
+
+          switch(fmt[i].type) {
+            case BCF_BT_INT8: GET_MAX_INDICES(int8_t, fmt[i].p, fmt[i].n, m); break;
+            case BCF_BT_INT16: GET_MAX_INDICES(int16_t, fmt[i].p, fmt[i].n, m); break;
+            case BCF_BT_INT32: GET_MAX_INDICES(int32_t, fmt[i].p, fmt[i].n, m); break;
+            case BCF_BT_FLOAT: GET_MAX_INDICES(float, fmt[i].p, fmt[i].n, m); break;
+            default: hts_log_error("Unexpected type %d", fmt[i].type); exit(1);
+          }
+
+          if (m.n == -1) {
+            out << GAP;
+          } else {
+            if (bcf_get_variant_types(v) == VCF_REF) {
+              out << v->d.allele[0];
+            } else if (bcf_get_variant_types(v) == VCF_SNP || bcf_get_variant_types(v) == VCF_MNP) {
+              nuc = (char *) malloc(INDEL_SIZE * sizeof(char));
+
+              get_consensus_indel(v->d.allele, m, nuc);
+              out << nuc;
+            } else {	// For INDEL insert difference.between reference and consensus allele
+              nuc =(char *) malloc(INDEL_SIZE * sizeof(char));
+              get_consensus_indel(v->d.allele, m, nuc);
+
+              s = strlen(v->d.allele[0]) - strlen(nuc); //  > 0 Deletion. < 0 INSERTION
+              d = (s > 0) ? strlen(v->d.allele[0]) : strlen(nuc);
+              r = (s > 0) ? v->d.allele[0] : nuc;
+              s = (s < 0) ? -1 * s : s;
+
+              if (v->pos == 499)
+                std::cout << "Number: " << m.n << " Maj Allele: " << v->d.allele[m.ind[0]] << strlen(nuc) << " - Nuc Length" << nuc << " " << s << " " << d << std::endl;
+
+              for (int i = 0; i < s; ++i) {
+                out << r[d - s];
+              }
+
+              free(m.ind);
+              free(nuc);
+              // std::cout << nuc << std::endl;
+            }
+          }
+        }
       }
+
       prev_pos = v->pos;
       ctr++;
-      if(ctr % 1000 == 0){
-	std::cout << ctr << std::endl;
+
+      if (ctr % 1000 == 0) {
+        std::cout << ctr << std::endl;
       }
     }
+
     bcf_destroy(v);
     bcf_hdr_destroy(header);
     bcf_close(in);
     out.close();
   }
+  
   return 0;
 }

--- a/src/call_consensus_pileup.cpp
+++ b/src/call_consensus_pileup.cpp
@@ -1,9 +1,10 @@
 #include "call_consensus_pileup.h"
 
-void format_alleles(std::vector<allele> &ad){
+void format_alleles(std::vector<allele> &ad) {
   std::vector<allele>::iterator it = ad.begin();
-  while(it < ad.end()){
-    if(it->nuc[0] == '-'){	// Remove deletions
+
+  while (it < ad.end()) {
+    if (it->nuc[0] == '-') {	// Remove deletions
       it = ad.erase(it);
     } else {
       ++it;
@@ -11,195 +12,239 @@ void format_alleles(std::vector<allele> &ad){
   }
 }
 
-bool compare_allele_depth(const allele &a, const allele &b){
+bool compare_allele_depth(const allele &a, const allele &b) {
   return b.depth < a.depth;
 }
 
-ret_t get_consensus_allele(std::vector<allele> ad, uint8_t min_qual, double threshold, char gap){
+ret_t get_consensus_allele(std::vector<allele> ad, uint8_t min_qual, double threshold, char gap) {
   ret_t t;
   t.nuc=gap;
   t.q = min_qual+33;
-  if(ad.size()==0)
+
+  if (ad.size()==0)
     return t;
+
   format_alleles(ad);
-  // if(ad.size() == 1){
+
+  // if (ad.size() == 1) {
   //   t.nuc = (ad.at(0).nuc.compare("*") == 0) ? "" : ad.at(0).nuc;
   //   t.q = (ad.at(0).nuc.compare("*") == 0) ? min_qual + 33 : ad.at(0).mean_qual + 33;
   //   return t;
   // }
+
   std::string cnuc = "";
   std::vector<allele> nuc_pos;
   allele tmp_a;
   char n;
   uint32_t max_l = 0, max_depth = 0, tmp_depth = 0, cur_depth = 0, total_max_depth = 0, gap_depth = 0, total_indel_depth = 0;
   uint8_t ambg_n = 1, ctr = 0;
+
   double q = 0, tq = 0, cur_threshold = 0;
   std::vector<allele>::iterator it;
-  for(std::vector<allele>::iterator it = ad.begin(); it != ad.end(); ++it) {
-    if(it->nuc.length() > max_l){
+
+  for (std::vector<allele>::iterator it = ad.begin(); it != ad.end(); ++it) {
+    if (it->nuc.length() > max_l) {
       max_l = it->nuc.length();
     }
-    if(it->nuc.length() == 1){
+
+    if (it->nuc.length() == 1) {
       total_max_depth += it->depth;
       total_indel_depth += it->depth;
       total_indel_depth = total_indel_depth - it->end; // For indels
     }
   }
+
   t.nuc = "";
   t.q = "";
-  for (uint16_t i = 0; i < max_l; ++i){
+
+  for (uint16_t i = 0; i < max_l; ++i) {
     n = '*';
     q = 0;
     tq = 0;
+
     max_depth = 0;
     tmp_depth = 0;
     cur_depth = 0;
     // prev_depth = 0;
+
     ctr = 1;
     it = ad.begin();
     gap_depth = 0;
     nuc_pos.clear();
-    while(it!=ad.end()){
-      if(!(i < it->nuc.length())){
-	it++;
-	continue;
+
+    while (it!=ad.end()) {
+      if (!(i < it->nuc.length())) {
+        it++;
+        continue;
       }
-      if(it->nuc[i] == '+' || it->nuc[i] == '-'){
-	it++;
-	continue;
+
+      if (it->nuc[i] == '+' || it->nuc[i] == '-') {
+        it++;
+        continue;
       }
+
       tmp_depth = it->depth;
       tq = it->mean_qual;
       ctr = 1;
-      while(it!=ad.end()-1 && i < (it+1)->nuc.length() && it->nuc[i] == (it+1)->nuc[i]){ // Third condition for cases with more than 1 base in insertion  && (i+1) < (it+1)->nuc.length()
-	tmp_depth += (it+1)->depth;
-	tq = ((tq * (ctr)) + (it+1)->mean_qual)/(ctr + 1);
-	it++;
-	ctr++;
+
+      while (it!=ad.end()-1 && i < (it+1)->nuc.length() && it->nuc[i] == (it+1)->nuc[i]) { // Third condition for cases with more than 1 base in insertion  && (i+1) < (it+1)->nuc.length()
+        tmp_depth += (it+1)->depth;
+        tq = ((tq * (ctr)) + (it+1)->mean_qual)/(ctr + 1);
+        it++;
+        ctr++;
       }
+
       cur_depth += tmp_depth;
       tmp_a.nuc = it->nuc[i];
       tmp_a.mean_qual = tq;
       tmp_a.reverse = 0;	// Reverse reads not important for consensus
       tmp_a.depth = tmp_depth;
       nuc_pos.push_back(tmp_a);
-      // if(tmp_depth > max_depth){
+
+      // if (tmp_depth > max_depth) {
       // 	n = it->nuc[i];
       // 	max_depth = tmp_depth;
       // 	q = tq;
       // 	ambg_n = 1;
-      // } else if(tmp_depth == max_depth){
+      // } else if (tmp_depth == max_depth) {
       // 	n = gt2iupac(n, it->nuc[i]);
       // 	q = ((q * ambg_n) + tq)/(ambg_n+1);
       // 	ambg_n += 1;
       // }
+
       it++;
     }
+
     // Sort nuc_pos by depth of alleles
     std::sort(nuc_pos.begin(), nuc_pos.end(), compare_allele_depth);
-    it=nuc_pos.begin();
+    it = nuc_pos.begin();
     n = it->nuc[0];
     q = it->mean_qual;
     max_depth = it->depth;
     it++;
     ambg_n = 1;
-    if(i > 0){
+
+    if (i > 0) {
       cur_threshold = threshold * (double) total_indel_depth;
     } else {
       cur_threshold =  threshold * (double)total_max_depth;
     }
-    while(it!=nuc_pos.end() && (max_depth < cur_threshold || it->depth == (it -1)->depth)){ // Iterate till end or till cross threshold and no more allele with same depth
+
+    while (it!=nuc_pos.end() && (max_depth < cur_threshold || it->depth == (it -1)->depth)) { // Iterate till end or till cross threshold and no more allele with same depth
       n = gt2iupac(n, it->nuc[0]);
       q = ((q * ambg_n) + it->mean_qual)/(ambg_n+1);
+
       ambg_n += 1;
       max_depth += it->depth;
+
       it++;
     }
-    if(max_depth < cur_threshold) // If depth still less than threshold
+
+    if (max_depth < cur_threshold) // If depth still less than threshold
       n = 'N';
-    if(i > 0)
+
+    if (i > 0)
       gap_depth = (total_indel_depth > cur_depth) ? total_indel_depth - cur_depth : 0;
     else
       gap_depth = 0;			  // For first position of allele
-    if(n!='*' && max_depth >= gap_depth){ // TODO: Check what to do when equal.{
+
+    if (n!='*' && max_depth >= gap_depth) { // TODO: Check what to do when equal.{
       t.nuc += n;
       q += 0.5;			// For rounding before converting to int
       t.q += (((uint8_t)q)+33);
     }
   }
+
   return t;
 }
 
-int call_consensus_from_plup(std::istream &cin, std::string seq_id, std::string out_file, uint8_t min_qual, double threshold, uint8_t min_depth, char gap, bool min_coverage_flag){
+int call_consensus_from_plup(std::istream &cin, std::string seq_id, std::string out_file, uint8_t min_qual, double threshold, uint8_t min_depth, char gap, bool min_coverage_flag) {
   std::string line, cell;
   std::ofstream fout((out_file+".fa").c_str());
   std::ofstream tmp_qout((out_file+".qual.txt").c_str());
+
   char *o = new char[out_file.length() + 1];
   strcpy(o, out_file.c_str());
-  if(seq_id.empty()) {
+
+  if (seq_id.empty()) {
     fout << ">Consensus_" << basename(o) << "_threshold_" << threshold << "_quality_" << (uint16_t) min_qual  <<std::endl;
   } else {
     fout << ">" << seq_id <<std::endl;
   }
+
   delete [] o;
+
   int ctr = 0, mdepth = 0;
   uint32_t prev_pos = 0, pos = 0;
   std::stringstream lineStream;
+
   char ref;
   std::string bases;
   std::string qualities;
+
   std::vector<allele> ad;
   uint32_t bases_zero_depth = 0, bases_min_depth = 0, total_bases = 0;
-  while (std::getline(cin, line)){
+
+  while (std::getline(cin, line)) {
     lineStream << line;
     ctr = 0;
     ref = 'N';
-    while(std::getline(lineStream,cell,'\t')){
-      switch(ctr){
-      case 0:
-	break;
-      case 1:
-	pos = stoi(cell);
-	break;
-      case 2:
-	ref = cell[0];
-	break;
-      case 3:
-	mdepth = stoi(cell);
-	break;
-      case 4:
-	bases = cell;
-	break;
-      case 5:
-	qualities = cell;
-	break;
-      case 6:
-	break;
+
+    while (std::getline(lineStream,cell,'\t')) {
+      switch(ctr) {
+        case 0:
+          break;
+        case 1:
+          pos = stoi(cell);
+          break;
+        case 2:
+          ref = cell[0];
+          break;
+        case 3:
+          mdepth = stoi(cell);
+          break;
+        case 4:
+          bases = cell;
+          break;
+        case 5:
+          qualities = cell;
+          break;
+        case 6:
+          break;
       }
+
       ctr++;
     }
+
     total_bases++;
-    if(prev_pos == 0)		// No -/N before alignment starts
+
+    if (prev_pos == 0)		// No -/N before alignment starts
       prev_pos = pos;
-    if((pos > prev_pos && min_coverage_flag)){
+
+    if ((pos > prev_pos && min_coverage_flag)) {
       fout << std::string((pos - prev_pos) - 1, gap);
       tmp_qout << std::string((pos - prev_pos) - 1, '!'); // ! represents 0 quality score.
     }
+
     ret_t t;
-    if(mdepth >= min_depth){
+
+    if (mdepth >= min_depth) {
       ad = update_allele_depth(ref, bases, qualities, min_qual);
       t = get_consensus_allele(ad, min_qual, threshold, gap);
       fout << t.nuc;
       tmp_qout << t.q;
-    } else{
+    } else {
       bases_min_depth += 1;
+
       if (mdepth == 0)
-	bases_zero_depth += 1;
-      if(min_coverage_flag){
-	fout << gap;
-	tmp_qout << '!';
+        bases_zero_depth += 1;
+
+      if (min_coverage_flag) {
+        fout << gap;
+        tmp_qout << '!';
       }
     }
+
     lineStream.clear();
     ad.clear();
     prev_pos = pos;
@@ -208,8 +253,10 @@ int call_consensus_from_plup(std::istream &cin, std::string seq_id, std::string 
   tmp_qout << "\n";
   tmp_qout.close();
   fout.close();
+
   std::cout << "Reference length: " << total_bases << std::endl;
   std::cout << "Positions with 0 depth: " << bases_zero_depth << std::endl;
   std::cout << "Positions with depth below " <<(unsigned) min_depth << ": " << bases_min_depth << std::endl;
+  
   return 0;
 }

--- a/src/call_variants.cpp
+++ b/src/call_variants.cpp
@@ -2,32 +2,38 @@
 
 const float sig_level = 0.01;
 
-std::vector<allele>::iterator get_ref_allele(std::vector<allele> &ad, char ref){
-  for(std::vector<allele>::iterator it = ad.begin(); it != ad.end(); ++it) {
-    if(it->nuc[0] == ref)
+std::vector<allele>::iterator get_ref_allele(std::vector<allele> &ad, char ref) {
+  for (std::vector<allele>::iterator it = ad.begin(); it != ad.end(); ++it) {
+    if (it->nuc[0] == ref)
       return it;
   }
+
   // print_allele_depths(ad);
+
   return ad.end();
 }
 
-double* get_frequency_depth(allele a, uint32_t pos_depth, uint32_t total_depth){ // pos_depth is ungapped depth after passing quality. total_depth is depth without quality filtering for indels.
+double* get_frequency_depth(allele a, uint32_t pos_depth, uint32_t total_depth) { // pos_depth is ungapped depth after passing quality. total_depth is depth without quality filtering for indels.
   double *val = new double[2];
-  if(a.nuc[0] == '+' || a.nuc[0] == '-'){	// For insertions and deletions use depth discarding quality
+
+  if (a.nuc[0] == '+' || a.nuc[0] == '-') {	// For insertions and deletions use depth discarding quality
     val[0] = a.depth/(double)total_depth;
     val[1] = total_depth;
     return val;
   }
+
   val[0] = a.depth/(double)pos_depth;
   val[1] = pos_depth;
+
   return val;
 }
 
-int call_variants_from_plup(std::istream &cin, std::string out_file, uint8_t min_qual, double min_threshold, uint8_t min_depth, std::string ref_path, std::string gff_path){
+int call_variants_from_plup(std::istream &cin, std::string out_file, uint8_t min_qual, double min_threshold, uint8_t min_depth, std::string ref_path, std::string gff_path) {
   std::string line, cell, bases, qualities, region;
   ref_antd refantd(ref_path, gff_path);
   std::ostringstream out_str;
   std::ofstream fout((out_file+".tsv").c_str());
+
   fout << "REGION"
     "\tPOS"
     "\tREF"
@@ -47,61 +53,72 @@ int call_variants_from_plup(std::istream &cin, std::string out_file, uint8_t min
     "\tREF_AA"
     "\tALT_CODON"
     "\tALT_AA"
-       << std::endl;
+    << std::endl;
+
   int ctr = 0;
   int64_t pos = 0;
   uint32_t mdepth = 0, pdepth = 0; // mpdepth for mpileup depth and pdeth for ungapped depth at position
+
   double pval_left, pval_right, pval_twotailed, *freq_depth, err;
   std::stringstream line_stream;
   char ref;
   std::vector<allele> ad;
   std::vector<allele>::iterator ref_it;
-  while (std::getline(cin, line)){
+
+  while (std::getline(cin, line)) {
     line_stream << line;
     ctr = 0;
     ref = 'N';
-    while(std::getline(line_stream,cell,'\t')){
-      switch(ctr){
-      case 0:
-	region = cell;
-	break;
-      case 1:
-	pos = stoi(cell);
-	break;
-      case 2:
-	ref = refantd.get_base(pos, region);
-	ref = (ref == 0) ? cell[0] : ref; // If ref does not exist then use from mpileup
-	break;
-      case 3:
-	mdepth = stoi(cell);
-	break;
-      case 4:
-	bases = cell;
-	break;
-      case 5:
-	qualities = cell;
-	break;
-      case 6:
-	break;
+
+    while (std::getline(line_stream,cell,'\t')) {
+      switch(ctr) {
+        case 0:
+          region = cell;
+          break;
+        case 1:
+          pos = stoi(cell);
+          break;
+        case 2:
+          ref = refantd.get_base(pos, region);
+          ref = (ref == 0) ? cell[0] : ref; // If ref does not exist then use from mpileup
+          break;
+        case 3:
+          mdepth = stoi(cell);
+          break;
+        case 4:
+          bases = cell;
+          break;
+        case 5:
+          qualities = cell;
+          break;
+        case 6:
+          break;
       }
+
       ctr++;
     }
+
     ad = update_allele_depth(ref, bases, qualities, min_qual);
-    if(ad.size() == 0){
+    if (ad.size() == 0) {
       line_stream.clear();
       continue;
     }
+
     // Get ungapped depth
     pdepth = 0;
-    for(std::vector<allele>::iterator it = ad.begin(); it != ad.end(); ++it) {
-      if(it->nuc[0]=='*' || it->nuc[0] == '+' || it->nuc[0] == '-')
-	continue;
+
+    for (std::vector<allele>::iterator it = ad.begin(); it != ad.end(); ++it) {
+      if (it->nuc[0]=='*' || it->nuc[0] == '+' || it->nuc[0] == '-')
+        continue;
+
       pdepth += it->depth;
     }
-    if(pdepth < min_depth) {	// Check for minimum depth
+
+    if (pdepth < min_depth) {	// Check for minimum depth
       line_stream.clear();
       continue;
     }
+
     ref_it = get_ref_allele(ad, ref);
     if (ref_it == ad.end()) {	// If ref not present in reads.
       allele a;
@@ -112,12 +129,16 @@ int call_variants_from_plup(std::istream &cin, std::string out_file, uint8_t min
       ad.push_back(a);
       ref_it = ad.end() - 1;
     }
-    for(std::vector<allele>::iterator it = ad.begin(); it != ad.end(); ++it) {
-      if((*it == *ref_it) || it->nuc[0]=='*')
-	continue;
+
+    for (std::vector<allele>::iterator it = ad.begin(); it != ad.end(); ++it) {
+      if ((*it == *ref_it) || it->nuc[0]=='*')
+        continue;
+
       freq_depth = get_frequency_depth(*it, pdepth, mdepth);
-      if(freq_depth[0] < min_threshold)
-	continue;
+
+      if (freq_depth[0] < min_threshold)
+        continue;
+
       out_str << region << "\t";
       out_str << pos << "\t";
       out_str << ref << "\t";
@@ -130,30 +151,39 @@ int call_variants_from_plup(std::istream &cin, std::string out_file, uint8_t min
       out_str << (uint16_t) it->mean_qual << "\t";
       out_str << freq_depth[0] << "\t";
       out_str << freq_depth[1] << "\t";
+
       /*
-	    | Var   | Ref      |
-	Exp | Error | Err free |
-	Obs | AD    | RD       |
+            | Var   | Ref      |
+        Exp | Error | Err free |
+        Obs | AD    | RD       |
        */
+
       err = pow(10, ( -1 * (it->mean_qual)/10));
       kt_fisher_exact((err * mdepth), (1-err) * mdepth, it->depth, ref_it->depth, &pval_left, &pval_right, &pval_twotailed);
       out_str << pval_left << "\t";
-      if(pval_left <= sig_level){
-	out_str << "TRUE" << "\t";
+      
+      if (pval_left <= sig_level) {
+        out_str << "TRUE" << "\t";
       } else {
-	out_str << "FALSE" << "\t";
+        out_str << "FALSE" << "\t";
       }
-      if(it->nuc[0] != '+' && it->nuc[0] != '-'){
-	refantd.codon_aa_stream(region, out_str, fout, pos, it->nuc[0]);
+
+      if (it->nuc[0] != '+' && it->nuc[0] != '-') {
+        refantd.codon_aa_stream(region, out_str, fout, pos, it->nuc[0]);
       } else {
-	fout << out_str.str() << "NA\tNA\tNA\tNA\tNA" << std::endl;
+        fout << out_str.str() << "NA\tNA\tNA\tNA\tNA" << std::endl;
       }
+
       out_str.str("");
       out_str.clear();
+
       delete[] freq_depth;
     }
+
     line_stream.clear();
   }
+
   fout.close();
+  
   return 0;
 }

--- a/src/get_common_variants.cpp
+++ b/src/get_common_variants.cpp
@@ -2,136 +2,160 @@
 
 const int NUM_FIELDS = 19;
 const std::string fields[NUM_FIELDS] = {"REGION",
-			      "POS",
-			      "REF",
-			      "ALT",
-			      "REF_DP",
-			      "REF_RV",
-			      "REF_QUAL",
-			      "ALT_DP",
-			      "ALT_RV",
-			      "ALT_QUAL",
-			      "ALT_FREQ",
-			      "TOTAL_DP",
-			      "PVAL",
-			      "PASS",
-			      "GFF_FEATURE",
-			      "REF_CODON",
-			      "REF_AA",
-			      "ALT_CODON",
-			      "ALT_AA"};
+            "POS",
+            "REF",
+            "ALT",
+            "REF_DP",
+            "REF_RV",
+            "REF_QUAL",
+            "ALT_DP",
+            "ALT_RV",
+            "ALT_QUAL",
+            "ALT_FREQ",
+            "TOTAL_DP",
+            "PVAL",
+            "PASS",
+            "GFF_FEATURE",
+            "REF_CODON",
+            "REF_AA",
+            "ALT_CODON",
+            "ALT_AA"};
 
 const std::string na_tab_delimited_str = "NA\tNA\tNA\tNA\tNA\tNA\tNA\tNA\tNA\tNA";
 
-int read_variant_file(std::ifstream &fin, unsigned int file_number, std::map<std::string, unsigned int> &counts, std::map<std::string, std::string> &file_tab_delimited_str){
+int read_variant_file(std::ifstream &fin, unsigned int file_number, std::map<std::string, unsigned int> &counts, std::map<std::string, std::string> &file_tab_delimited_str) {
   unsigned int ctr;
+
   std::string line, cell, tab_delimited_key, tab_delimited_val;
   std::stringstream line_stream;
   std::string region, ref, alt;
+
   // Make sure format of header matches
   std::getline(fin, line);
   line_stream << line;
   ctr = 0;
-  while(std::getline(line_stream,cell,'\t')){
-    if(cell.compare(fields[ctr]) != 0){
+
+  while (std::getline(line_stream,cell,'\t')) {
+    if (cell.compare(fields[ctr]) != 0) {
       return -1;
     }
+
     ctr++;
   }
+
   line_stream.clear();
-  while (std::getline(fin, line)){
+
+  while (std::getline(fin, line)) {
     line_stream << line;
     ctr = 0;
+
     tab_delimited_key = "";
     tab_delimited_val = "";
-    while(std::getline(line_stream,cell,'\t')){
-      switch(ctr){
-      case 0:			// REGION
-      case 1:			// POS
-      case 2:			// REF
-      case 3:			// ALT
-      case 14:			// GFF_FEATURE
-      case 15:			// REF_CODON
-      case 16:			// REF_AA
-      case 17:			// ALT_CODON
-      case 18:			// ALT_AA
-	tab_delimited_key += cell + "\t";
-	break;
-      case 4:
-      case 5:
-      case 6:
-      case 7:
-      case 8:
-      case 9:
-      case 10:
-      case 11:
-      case 12:
-      case 13:
-      default:
-	tab_delimited_val += cell;
-	if(ctr < 13){
-	  tab_delimited_val += "\t";
-	}
-	break;
+
+    while (std::getline(line_stream,cell,'\t')) {
+      switch(ctr) {
+        case 0:			// REGION
+        case 1:			// POS
+        case 2:			// REF
+        case 3:			// ALT
+        case 14:			// GFF_FEATURE
+        case 15:			// REF_CODON
+        case 16:			// REF_AA
+        case 17:			// ALT_CODON
+        case 18:			// ALT_AA
+          tab_delimited_key += cell + "\t";
+          break;
+        case 4:
+        case 5:
+        case 6:
+        case 7:
+        case 8:
+        case 9:
+        case 10:
+        case 11:
+        case 12:
+        case 13:
+        default:
+          tab_delimited_val += cell;
+          if (ctr < 13) {
+            tab_delimited_val += "\t";
+          }
+          break;
       }
+
       ctr++;
     }
-    if(counts.find(tab_delimited_key) == counts.end()){
+
+    if (counts.find(tab_delimited_key) == counts.end()) {
       counts[tab_delimited_key] = 1;
     } else {
       counts[tab_delimited_key] += 1;
     }
+
     file_tab_delimited_str[tab_delimited_key + std::to_string(file_number)] = tab_delimited_val;
     line_stream.clear();
   }
+
   return 0;
 }
 
-int common_variants(std::string out, double min_threshold, char* files[], unsigned int nfiles){
+int common_variants(std::string out, double min_threshold, char* files[], unsigned int nfiles) {
   out += ".tsv";
   std::ofstream fout(out.c_str());
   unsigned int i, j;
+
   std::ifstream fin;
   std::map<std::string, unsigned int> counts = std::map<std::string, unsigned int>();
   std::map<std::string, std::string> file_tab_delimited_str = std::map<std::string, std::string>();
+
   for (i = 0; i < nfiles; ++i) {
     fin.open(files[i]);
-    if(read_variant_file(fin, i, counts, file_tab_delimited_str) != 0){
+
+    if (read_variant_file(fin, i, counts, file_tab_delimited_str) != 0) {
       std::cout << "Header format of "  << files[i]  << " did not match!";
       std::cout << " Please use files generated using \"ivar variants\" command." << std::endl;
     }
+
     fin.close();
   }
+
   std::map<std::string, unsigned int>::iterator it = counts.begin();
+
   // Write header
   for (i = 0; i < 4; ++i) {
     fout << fields[i] << "\t";
   }
+
   for (i = 14; i < 19; ++i) {
     fout << fields[i] << "\t";
   }
+
   for (i = 0; i < nfiles; ++i) {
     for (j = 4; j < 14; ++j) {
       fout << fields[j] << "_" << files[i] << "\t";
     }
   }
+
   fout << "\n";
+
   // Write rows
-  while(it != counts.end()){
-    if(((float)it->second)/(float)nfiles >= min_threshold){ // Check if variant occurs in more 'min_threshold' fraction of files
+  while (it != counts.end()) {
+    if (((float)it->second)/(float)nfiles >= min_threshold) { // Check if variant occurs in more 'min_threshold' fraction of files
       fout << it->first;
       for (j = 0; j < nfiles; ++j) {
-	if(file_tab_delimited_str.find(it->first + std::to_string(j)) == file_tab_delimited_str.end()){
-	  fout << na_tab_delimited_str;
-	} else {
-	  fout << file_tab_delimited_str[it->first + std::to_string(j)];
-	}
-	if(j < nfiles - 1)
-	  fout << "\t";
+        if (file_tab_delimited_str.find(it->first + std::to_string(j)) == file_tab_delimited_str.end()) {
+          fout << na_tab_delimited_str;
+        } else {
+          fout << file_tab_delimited_str[it->first + std::to_string(j)];
+        }
+
+        if (j < nfiles - 1)
+          fout << "\t";
       }
       fout << "\n";
     }
     it++;
   }
+
   return 0;
 }

--- a/src/get_masked_amplicons.cpp
+++ b/src/get_masked_amplicons.cpp
@@ -1,67 +1,81 @@
 #include "get_masked_amplicons.h"
 
-int get_primers_with_mismatches(std::string bed, std::string vpath, std::string out, std::string primer_pair_file){
+int get_primers_with_mismatches(std::string bed, std::string vpath, std::string out, std::string primer_pair_file) {
   std::vector<primer> primers = populate_from_file(bed);
   std::vector<primer> mismatches_primers;
   std::vector<primer> tmp;
-  if(primers.size() == 0){
+
+  if (primers.size() == 0) {
     return 0;
   }
+
   populate_pair_indices(primers, primer_pair_file);
   std::string line, cell;
   std::ifstream fin(vpath.c_str());
   out += ".txt";
   std::ofstream fout(out.c_str());
+
   unsigned int ctr, pos;
   std::stringstream line_stream;
-  while (std::getline(fin, line)){
+
+  while (std::getline(fin, line)) {
     line_stream << line;
     ctr = 0;
     pos = 0;
-    while(std::getline(line_stream,cell,'\t')){
-      switch(ctr){
-      case 1:
-	if(cell != "POS")
-	  pos = stoi(cell);
-	break;
-      default:
-	break;
+    while (std::getline(line_stream,cell,'\t')) {
+      switch(ctr) {
+        case 1:
+          if (cell != "POS")
+            pos = stoi(cell);
+          break;
+        default:
+          break;
       }
+
       ctr++;
     }
-    if(pos == 0){
+
+    if (pos == 0) {
       line_stream.clear();
       continue;
     }
+
     pos--;			// 1 based to 0 based
     tmp = get_primers(primers, pos);
+
     // mismatches_primers.insert(mismatches_primers.end(), tmp.begin(), tmp.end());
     std::vector<primer>::iterator tmp_it;
-    for(std::vector<primer>::iterator it = tmp.begin(); it != tmp.end(); ++it) {
+    for (std::vector<primer>::iterator it = tmp.begin(); it != tmp.end(); ++it) {
       tmp_it = std::find(mismatches_primers.begin(), mismatches_primers.end(), *it);
-      if(tmp_it == mismatches_primers.end()){
-	std::cout << it->get_name() << std::endl;
-	mismatches_primers.push_back(*it);
+      if (tmp_it == mismatches_primers.end()) {
+        std::cout << it->get_name() << std::endl;
+        mismatches_primers.push_back(*it);
       }
+
       // Look for primer pair
-      if(it->get_pair_indice() != -1){
-	tmp_it = std::find(mismatches_primers.begin(), mismatches_primers.end(), primers.at(it->get_pair_indice()));
-	if(tmp_it == mismatches_primers.end()){
-	  mismatches_primers.push_back(primers.at(it->get_pair_indice()));
-	}
+      if (it->get_pair_indice() != -1) {
+        tmp_it = std::find(mismatches_primers.begin(), mismatches_primers.end(), primers.at(it->get_pair_indice()));
+        if (tmp_it == mismatches_primers.end()) {
+          mismatches_primers.push_back(primers.at(it->get_pair_indice()));
+        }
       }
     }
+
     line_stream.clear();
     tmp.clear();
   }
-  for(std::vector<primer>::iterator it = mismatches_primers.begin(); it != mismatches_primers.end(); ++it) {
+
+  for (std::vector<primer>::iterator it = mismatches_primers.begin(); it != mismatches_primers.end(); ++it) {
     fout << it->get_name();
     std::cout << it->get_name();
-    if(it != mismatches_primers.end() - 1){
+
+    if (it != mismatches_primers.end() - 1) {
       fout << "\t";
       std::cout << "\t";
     }
   }
+
   std::cout << std::endl;
+  
   return 0;
 }

--- a/src/interval_tree.cpp
+++ b/src/interval_tree.cpp
@@ -1,59 +1,61 @@
 #include "interval_tree.h"
 
 // Constructor for initializing an Interval Tree
-IntervalTree::IntervalTree(){
+IntervalTree::IntervalTree() {
   _root = NULL;
 }
 
 // A utility function to insert a new Interval Search Tree Node
 // This is similar to BST Insert.  Here the low value of interval
 // is used tomaintain BST property
-void IntervalTree::insert(ITNode *root, Interval data){
+void IntervalTree::insert(ITNode *root, Interval data) {
   // Base case: Tree is empty, new node becomes root
-  if(root == NULL){
+  if (root == NULL) {
     root = new ITNode(data);
     _root = root;
   } else {
     // Get low value of interval at root
     int l = root->data->low;
+
     // If root's low value is greater, then new interval goes to
     // left subtree
-    if (data.low < l){
-      if(!root->left){
-	ITNode *tmpNode = new ITNode(data);
-	//std::cout << data.low << ":" << data.high << "->insertLeft" << std::endl;
-	root->left = tmpNode;
+    if (data.low < l) {
+      if (!root->left) {
+        ITNode *tmpNode = new ITNode(data);
+        //std::cout << data.low << ":" << data.high << "->insertLeft" << std::endl;
+        root->left = tmpNode;
       } else {
-	insert(root->left, data);
+        insert(root->left, data);
       }
-    }
-    else {
-      if(!root->right){
-	ITNode *tmpNode = new ITNode(data);
-	//std::cout << data.low << ":" << data.high << "->insertRight" << std::endl;
-	root->right = tmpNode;
+    } else {
+      if (!root->right) {
+        ITNode *tmpNode = new ITNode(data);
+        //std::cout << data.low << ":" << data.high << "->insertRight" << std::endl;
+        root->right = tmpNode;
       } else {
-	insert(root->right, data);
+        insert(root->right, data);
       }
     }
   }
+
   // update max value of ancestor node
-  if(root->max < data.high)
+  if (root->max < data.high)
     root->max = data.high;
 }
 
 
 // A utility function to check if the 1st interval envelops the second
-bool doEnvelop(Interval i1, Interval i2){
-  if(i1.low <= i2.low && i1.high >= i2.high)
+bool doEnvelop(Interval i1, Interval i2) {
+  if (i1.low <= i2.low && i1.high >= i2.high)
     return true;
+
   return false;
 }
 
 
 // The main function that searches an interval i in a given
 // Interval Tree.
-bool IntervalTree::envelopSearch(ITNode *root, Interval i){
+bool IntervalTree::envelopSearch(ITNode *root, Interval i) {
   // Base Case, tree is empty
   //std::cout << root->data->low << ":" << root->data->high << std::endl;
   if (root == NULL) return false;
@@ -73,54 +75,58 @@ bool IntervalTree::envelopSearch(ITNode *root, Interval i){
 }
 
 // A helper function for inorder traversal of the tree
-void IntervalTree::inOrder(ITNode *root){
+void IntervalTree::inOrder(ITNode *root) {
   if (root == NULL) return;
+
   inOrder(root->left);
+
   cout << "[" << root->data->low << ", " << root->data->high << "]"
        << " max = " << root->max << endl;
+       
   inOrder(root->right);
 }
 
 // A stand-alone function to create a tree containing the coordinates of each amplicon
 // based on user-specified primer pairs
-IntervalTree populate_amplicons(std::string pair_info_file, std::vector<primer> primers){
+IntervalTree populate_amplicons(std::string pair_info_file, std::vector<primer> primers) {
   int amplicon_start = -1;
   int amplicon_end = -1;
   IntervalTree tree = IntervalTree();
   populate_pair_indices(primers, pair_info_file);
+
   for (auto & p : primers) {
-    if (p.get_strand() == '+')
-      {
-	if (p.get_pair_indice() != -1){
-	  amplicon_start = p.get_start();
-	  amplicon_end = primers[p.get_pair_indice()].get_end() + 1;
-	  tree.insert(Interval(amplicon_start, amplicon_end));
-	}
+    if (p.get_strand() == '+') {
+      if (p.get_pair_indice() != -1) {
+        amplicon_start = p.get_start();
+        amplicon_end = primers[p.get_pair_indice()].get_end() + 1;
+        tree.insert(Interval(amplicon_start, amplicon_end));
       }
+    }
   }
+  
   return tree;
 }
 
 
 /*
 // Simple access functions to retrieve node's interval data
-Interval ITNode::getData()const{
+Interval ITNode::getData()const {
 return data;
 }
 // Simple access functions to retrieve node's left child
-ITNode ITNode::getLeft()const{
+ITNode ITNode::getLeft()const {
 return left;
 }
 // Simple access functions to retrieve node's right child
-ITNode ITNode::getRight()const{
+ITNode ITNode::getRight()const {
 return right;
 }
 // Simple access functions to set node's left child
-void ITNode::setLeft(ITNode *node){
+void ITNode::setLeft(ITNode *node) {
 left = node;
 }
 // Simple access functions to set node's right child
-void ITNode::setRight(ITNode *node){
+void ITNode::setRight(ITNode *node) {
 right = node;
 }
 

--- a/src/ivar.cpp
+++ b/src/ivar.cpp
@@ -19,28 +19,28 @@
 const std::string VERSION = "1.3.1";
 
 struct args_t {
-  std::string bam;		// -i
-  std::string bed;		// -b
-  std::string text;		// -t
-  std::string seq_id; // -i for consensus
-  std::string prefix;		// -p
-  std::string ref;		// -r
-  std::string region;		// -R
-  uint8_t min_qual;		// -q
-  uint8_t sliding_window;	// -s
-  double min_threshold;	// -t
-  int min_length;		// -m
-  std::string f1;		// -1
-  std::string f2;		// -2
-  std::string adp_path;	// -a
-  uint8_t min_depth;		// -m
-  char gap;			// -n
-  bool keep_min_coverage;	// -k
+  std::string bam;		          // -i
+  std::string bed;		          // -b
+  std::string text;		          // -t
+  std::string seq_id;           // -i for consensus
+  std::string prefix;		        // -p
+  std::string ref;		          // -r
+  std::string region;		        // -R
+  uint8_t min_qual;		          // -q
+  uint8_t sliding_window;      	// -s
+  double min_threshold;	        // -t
+  int min_length;		            // -m
+  std::string f1;		            // -1
+  std::string f2;		            // -2
+  std::string adp_path;	        // -a
+  uint8_t min_depth;		        // -m
+  char gap;			                // -n
+  bool keep_min_coverage;	      // -k
   std::string primer_pair_file;	// -f
-  int32_t primer_offset; // -x
-  std::string file_list;		// -f
-  bool write_no_primers_flag;	// -e
-  std::string gff;		// -g
+  int32_t primer_offset;        // -x
+  std::string file_list;		    // -f
+  bool write_no_primers_flag;	  // -e
+  std::string gff;		          // -g
   bool keep_for_reanalysis;     // -k
 } g_args;
 
@@ -176,11 +176,12 @@ static const char *getmasked_opt_str = "i:b:f:p:h?";
 static const char *trimadapter_opt_str = "1:2:p:a:h?";
 
 std::string get_filename_without_extension(std::string f, std::string ext){
-  if(ext.length() > f.length())	// If extension longer than filename
+  if (ext.length() > f.length())	// If extension longer than filename
     return f;
-  if(f.substr(f.length()-ext.length(), ext.length()).compare(ext) == 0){
+
+  if (f.substr(f.length()-ext.length(), ext.length()).compare(ext) == 0)
     return f.substr(0,f.length()-ext.length());
-  }
+
   return f;
 }
 
@@ -192,30 +193,36 @@ std::string get_filename_without_extension(std::string f, std::string ext){
  */
 
 int main(int argc, char* argv[]){
-  if(argc == 1){
+  if (argc == 1) {
     print_usage();
     return -1;
   }
+
   std::stringstream cl_cmd;
   cl_cmd << "@PG\tID:ivar-" << argv[1]  <<  "\tPN:ivar\tVN:" << VERSION << "\tCL:" << argv[0] << " ";
+
   for (int i = 1; i < argc; ++i) {
     cl_cmd << argv[i];
-    if(i != argc-1)
+    if (i != argc-1)
       cl_cmd << " ";
   }
+
   cl_cmd << "\n\0";
   std::string cmd(argv[1]);
-  if(cmd.compare("-v") == 0){
+
+  if (cmd.compare("-v") == 0) {
     print_version_info();
     return 0;
   }
+
   int opt = 0, res = 0;
   // Sift arg by 1 for getopt
   argv[1] = argv[0];
   argv++;
   argc--;
+
   // ivar trim
-  if (cmd.compare("trim") == 0){
+  if (cmd.compare("trim") == 0) {
     g_args.min_qual = 20;
     g_args.sliding_window = 4;
     g_args.min_length = 30;
@@ -225,113 +232,121 @@ int main(int argc, char* argv[]){
     g_args.primer_pair_file = "";
     g_args.primer_offset = 0;
     opt = getopt( argc, argv, trim_opt_str);
-    while( opt != -1 ) {
+
+    while ( opt != -1 ) {
       switch( opt ) {
-      case 'i':
-	g_args.bam = optarg;
-	break;
-      case 'b':
-	g_args.bed = optarg;
-	break;
-      case 'f':
-  g_args.primer_pair_file = optarg;
-  break;
-      case 'x':
-  g_args.primer_offset = std::stoi(optarg);
-  break;
-      case 'p':
-	g_args.prefix = optarg;
-	break;
-      case 'm':
-	g_args.min_length = std::stoi(optarg);
-	break;
-      case 'q':
-	g_args.min_qual = std::stoi(optarg);
-	break;
-      case 's':
-	g_args.sliding_window = std::stoi(optarg);
-	break;
-      case 'e':
-	g_args.write_no_primers_flag = true;
-	break;
-      case 'k':
-        g_args.keep_for_reanalysis = true;
-        break;
-      case 'h':
-      case '?':
-	print_trim_usage();
-	return -1;
-	break;
+        case 'i':
+          g_args.bam = optarg;
+          break;
+        case 'b':
+          g_args.bed = optarg;
+          break;
+        case 'f':
+          g_args.primer_pair_file = optarg;
+          break;
+        case 'x':
+          g_args.primer_offset = std::stoi(optarg);
+          break;
+        case 'p':
+          g_args.prefix = optarg;
+          break;
+        case 'm':
+          g_args.min_length = std::stoi(optarg);
+          break;
+        case 'q':
+          g_args.min_qual = std::stoi(optarg);
+          break;
+        case 's':
+          g_args.sliding_window = std::stoi(optarg);
+          break;
+        case 'e':
+          g_args.write_no_primers_flag = true;
+          break;
+        case 'k':
+          g_args.keep_for_reanalysis = true;
+          break;
+        case 'h':
+        case '?':
+          print_trim_usage();
+          return -1;
       }
       opt = getopt( argc, argv, trim_opt_str);
     }
-    if(g_args.bam.empty() || g_args.prefix.empty()){
+
+    if (g_args.bam.empty() || g_args.prefix.empty()) {
       print_trim_usage();
       return -1;
     }
+
     g_args.prefix = get_filename_without_extension(g_args.prefix,".bam");
     res = trim_bam_qual_primer(g_args.bam, g_args.bed, g_args.prefix, g_args.region, g_args.min_qual, g_args.sliding_window, cl_cmd.str(), g_args.write_no_primers_flag, g_args.keep_for_reanalysis, g_args.min_length, g_args.primer_pair_file, g_args.primer_offset);
   }
+
   // ivar variants
-  else if (cmd.compare("variants") == 0){
+  else if (cmd.compare("variants") == 0) {
     g_args.min_qual = 20;
     g_args.min_threshold = 0.03;
     g_args.min_depth = 0;
     g_args.ref = "";
     g_args.gff = "";
+
     opt = getopt( argc, argv, variants_opt_str);
     while( opt != -1 ) {
       switch( opt ) {
-      case 'p':
-	g_args.prefix = optarg;
-	break;
-      case 't':
-	g_args.min_threshold = atof(optarg);
-	break;
-      case 'q':
-	g_args.min_qual = std::stoi(optarg);
-	break;
-      case 'm':
-	g_args.min_depth = std::stoi(optarg);
-	break;
-      case 'r':
-	g_args.ref = optarg;
-	break;
-      case 'g':
-	g_args.gff = optarg;
-	break;
-      case 'h':
-      case '?':
-	print_variants_usage();
-	return 0;
-	break;
+        case 'p':
+          g_args.prefix = optarg;
+          break;
+        case 't':
+          g_args.min_threshold = atof(optarg);
+          break;
+        case 'q':
+          g_args.min_qual = std::stoi(optarg);
+          break;
+        case 'm':
+          g_args.min_depth = std::stoi(optarg);
+          break;
+        case 'r':
+          g_args.ref = optarg;
+          break;
+        case 'g':
+          g_args.gff = optarg;
+          break;
+        case 'h':
+        case '?':
+          print_variants_usage();
+          return 0;
       }
       opt = getopt( argc, argv, variants_opt_str);
     }
-    if(g_args.prefix.empty()){
+
+    if (g_args.prefix.empty()) {
       print_variants_usage();
       return -1;
     }
-    if(g_args.gff.empty())
+
+    if (g_args.gff.empty())
       std::cout << "A GFF file containing the open reading frames (ORFs) has not been provided. Amino acid translation will not be done." << std::endl;
-    if(g_args.ref.empty())
+
+    if (g_args.ref.empty())
       std::cout << "A reference sequence has not been supplied. Amino acid translation will not be done." << std::endl;
-    if(!g_args.gff.empty() && g_args.ref.empty()){ // GFF specified but no reference then exit
+
+    if (!g_args.gff.empty() && g_args.ref.empty()) { // GFF specified but no reference then exit
       std::cout << "Please specify reference (using -r) based on which the GFF file was computed." << std::endl;
       print_variants_usage();
       return -1;
     }
+
     g_args.prefix = get_filename_without_extension(g_args.prefix,".tsv");
     g_args.min_threshold = (g_args.min_threshold < 0 || g_args.min_threshold > 1) ? 0.03: g_args.min_threshold;
-    if(isatty(STDIN_FILENO)){
+
+    if (isatty(STDIN_FILENO)) {
       std::cout << "Please pipe mpileup into `ivar variants` command.\n\n";
       print_variants_usage();
       return -1;
     }
+
     res = call_variants_from_plup(std::cin, g_args.prefix, g_args.min_qual, g_args.min_threshold, g_args.min_depth, g_args.ref, g_args.gff);
-  }
-  // ivar consensus
-  else if (cmd.compare("consensus") == 0){
+  } else if (cmd.compare("consensus") == 0) { // ivar consensus
     opt = getopt( argc, argv, consensus_opt_str);
     g_args.seq_id = "";
     g_args.min_threshold = 0;
@@ -339,219 +354,239 @@ int main(int argc, char* argv[]){
     g_args.gap = 'N';
     g_args.min_qual = 20;
     g_args.keep_min_coverage = true;
+
     while( opt != -1 ) {
       switch( opt ) {
-      case 't':
-	g_args.min_threshold = atof(optarg);
-	break;
-      case 'i':
-	g_args.seq_id = optarg;
-	break;
-      case 'p':
-	g_args.prefix = optarg;
-	break;
-      case 'm':
-	g_args.min_depth = std::stoi(optarg);
-	break;
-      case 'n':
-	g_args.gap = optarg[0];
-	break;
-      case 'q':
-	g_args.min_qual = std::stoi(optarg);
-	break;
-      case 'k':
-	g_args.keep_min_coverage = false;
-      case 'g':
-	break;
-      case 'h':
-      case '?':
-	print_consensus_usage();
-	return 0;
-	break;
+        case 't':
+          g_args.min_threshold = atof(optarg);
+          break;
+        case 'i':
+          g_args.seq_id = optarg;
+          break;
+        case 'p':
+          g_args.prefix = optarg;
+          break;
+        case 'm':
+          g_args.min_depth = std::stoi(optarg);
+          break;
+        case 'n':
+          g_args.gap = optarg[0];
+          break;
+        case 'q':
+          g_args.min_qual = std::stoi(optarg);
+          break;
+        case 'k':
+          g_args.keep_min_coverage = false;
+        case 'g':
+          break;
+        case 'h':
+        case '?':
+          print_consensus_usage();
+          return 0;
       }
       opt = getopt( argc, argv, consensus_opt_str);
     }
-    if(g_args.prefix.empty()){
+
+    if (g_args.prefix.empty()) {
       print_consensus_usage();
       return -1;
     }
-    if(isatty(STDIN_FILENO)){
+
+    if (isatty(STDIN_FILENO)) {
       std::cout << "Please pipe mpileup into `ivar consensus` command.\n\n";
       print_consensus_usage();
       return -1;
     }
+
     g_args.prefix = get_filename_without_extension(g_args.prefix,".fa");
     g_args.prefix = get_filename_without_extension(g_args.prefix,".fasta");
     g_args.gap = (g_args.gap != 'N' && g_args.gap != '-') ? 'N' : g_args.gap; // Accept only N or -
+
     std::cout <<"Minimum Quality: " << (uint16_t) g_args.min_qual << std::endl;
     std::cout << "Threshold: " << g_args.min_threshold << std::endl;
     std::cout << "Minimum depth: " << (unsigned) g_args.min_depth << std::endl;
-    if(!g_args.keep_min_coverage)
+
+    if (!g_args.keep_min_coverage)
       std::cout << "Regions with depth less than minimum depth will not added to consensus" << std::endl;
     else
       std::cout << "Regions with depth less than minimum depth covered by: " << g_args.gap << std::endl;
+    
     res = call_consensus_from_plup(std::cin, g_args.seq_id, g_args.prefix, g_args.min_qual, g_args.min_threshold, g_args.min_depth, g_args.gap, g_args.keep_min_coverage);
-  } else if (cmd.compare("removereads") == 0){
+  } else if (cmd.compare("removereads") == 0) {
     opt = getopt( argc, argv, removereads_opt_str);
     while( opt != -1 ) {
       switch( opt ) {
-      case 'i':
-	g_args.bam = optarg;
-	break;
-      case 't':
-	g_args.text = optarg;
-	break;
-      case 'b':
-	g_args.bed = optarg;
-	break;
-      case 'p':
-	g_args.prefix = optarg;
-	break;
-      case 'h':
-      case '?':
-	print_removereads_usage();
-	return 0;
-	break;
+        case 'i':
+          g_args.bam = optarg;
+          break;
+        case 't':
+          g_args.text = optarg;
+          break;
+        case 'b':
+          g_args.bed = optarg;
+          break;
+        case 'p':
+          g_args.prefix = optarg;
+          break;
+        case 'h':
+        case '?':
+          print_removereads_usage();
+          return 0;
       }
       opt = getopt( argc, argv, removereads_opt_str);
     }
-    if(g_args.bam.empty() || g_args.prefix.empty() || g_args.bed.empty() || g_args.text.empty()){
+
+    if (g_args.bam.empty() || g_args.prefix.empty() || g_args.bed.empty() || g_args.text.empty()) {
       print_removereads_usage();
       return -1;
     }
+
     std::string s;
     std::vector<std::string> amp;
     std::ifstream fin(g_args.text.c_str());
-    while(getline(fin, s, '\t' ) ){
+    while (getline(fin, s, '\t' ) ) {
       amp.push_back(s);
     }
     fin.close();
+
     g_args.prefix = get_filename_without_extension(g_args.prefix,".bam");
     res = rmv_reads_from_amplicon(g_args.bam, g_args.region, g_args.prefix, amp, g_args.bed, cl_cmd.str());
-  } else if(cmd.compare("filtervariants") == 0){
+  } else if (cmd.compare("filtervariants") == 0) {
     opt = getopt( argc, argv, filtervariants_opt_str);
     g_args.min_threshold = 1;
-    while( opt != -1 ) {
+    while ( opt != -1 ) {
       switch( opt ) {
-      case 'p':
-	g_args.prefix = optarg;
-	break;
-      case 't':
-	g_args.min_threshold = atof(optarg);
-	break;
-      case 'f':
-	g_args.file_list = optarg;
-	break;
-      case 'h':
-      case '?':
-	print_filtervariants_usage();
-	return 0;
-	break;
+        case 'p':
+          g_args.prefix = optarg;
+          break;
+        case 't':
+          g_args.min_threshold = atof(optarg);
+          break;
+        case 'f':
+          g_args.file_list = optarg;
+          break;
+        case 'h':
+        case '?':
+          print_filtervariants_usage();
+          return 0;
       }
       opt = getopt( argc, argv, filtervariants_opt_str);
     }
-    if(g_args.min_threshold < 0 || g_args.min_threshold > 1){
+
+    if (g_args.min_threshold < 0 || g_args.min_threshold > 1) {
       print_filtervariants_usage();
       return -1;
     }
-    if(optind >= argc && g_args.file_list.empty()){
+
+    if (optind >= argc && g_args.file_list.empty()) {
       print_filtervariants_usage();
       return -1;
     }
-    if(g_args.prefix.empty()){
+
+    if (g_args.prefix.empty()) {
       print_filtervariants_usage();
       return -1;
     }
+
     g_args.prefix = get_filename_without_extension(g_args.prefix,".tsv");
+
     // Read files from list
     char **files = new char*[100];
     int nfiles = 100, ctr = 0;
     std::string line;
-    if (!g_args.file_list.empty()){	// File list supplied
+    if (!g_args.file_list.empty()) {	// File list supplied
       std::ifstream file_fin = std::ifstream(g_args.file_list);
-      while (std::getline(file_fin, line)){
-	files[ctr] = strdup(line.c_str());
-	if(ctr == nfiles - 1){
-	  nfiles += 100;
-	  *files = (char*) realloc(*files, nfiles * (sizeof(char*)));
-	}
-	ctr++;
+      while (std::getline(file_fin, line)) {
+        files[ctr] = strdup(line.c_str());
+
+        if(ctr == nfiles - 1){
+          nfiles += 100;
+          *files = (char*) realloc(*files, nfiles * (sizeof(char*)));
+        }
+
+        ctr++;
       }
       file_fin.close();
+
       nfiles = (nfiles > ctr) ? ctr : nfiles;
       res = common_variants(g_args.prefix, g_args.min_threshold, files, nfiles);
+
       // Free files, nfiles
       for (int i = 0; i < nfiles; ++i) {
-	free(files[i]);
+        free(files[i]);
       }
+
       free(files);
     } else {
       res = common_variants(g_args.prefix, g_args.min_threshold, argv + optind, argc - optind);
     }
-  } else if(cmd.compare("getmasked") == 0){
+  } else if (cmd.compare("getmasked") == 0) {
     opt = getopt( argc, argv, getmasked_opt_str);
     while( opt != -1 ) {
       switch( opt ) {
-      case 'i':
-	g_args.bam = optarg;
-	break;
-      case 'b':
-	g_args.bed = optarg;
-	break;
-      case 'f':
-	g_args.primer_pair_file = optarg;
-	break;
-      case 'p':
-	g_args.prefix = optarg;
-	break;
-      case 'h':
-      case '?':
-	print_getmasked_usage();
-	return 0;
-	break;
+        case 'i':
+          g_args.bam = optarg;
+          break;
+        case 'b':
+          g_args.bed = optarg;
+          break;
+        case 'f':
+          g_args.primer_pair_file = optarg;
+          break;
+        case 'p':
+          g_args.prefix = optarg;
+          break;
+        case 'h':
+        case '?':
+          print_getmasked_usage();
+          return 0;
       }
       opt = getopt( argc, argv, getmasked_opt_str);
     }
-    if(g_args.bed.empty() || g_args.bam.empty() || g_args.prefix.empty() || g_args.primer_pair_file.empty()){
+
+    if (g_args.bed.empty() || g_args.bam.empty() || g_args.prefix.empty() || g_args.primer_pair_file.empty()) {
       print_getmasked_usage();
       return -1;
     }
+
     g_args.prefix = get_filename_without_extension(g_args.prefix,".txt");
     res = get_primers_with_mismatches(g_args.bed, g_args.bam, g_args.prefix, g_args.primer_pair_file);
-  } else if (cmd.compare("trimadapter") == 0){
+  } else if (cmd.compare("trimadapter") == 0) {
     opt = getopt( argc, argv, trimadapter_opt_str);
     while( opt != -1 ) {
       switch( opt ) {
-      case '1':
-	g_args.f1 = optarg;
-	break;
-      case '2':
-	g_args.f2 = optarg;
-	break;
-      case 'p':
-	g_args.prefix = optarg;
-	break;
-      case 'a':
-	g_args.adp_path = optarg;
-	break;
-      case 'h':
-      case '?':
-	print_trimadapter_usage();
-	return 0;
-	break;
+        case '1':
+          g_args.f1 = optarg;
+          break;
+        case '2':
+          g_args.f2 = optarg;
+          break;
+        case 'p':
+          g_args.prefix = optarg;
+          break;
+        case 'a':
+          g_args.adp_path = optarg;
+          break;
+        case 'h':
+        case '?':
+          print_trimadapter_usage();
+          return 0;
       }
       opt = getopt( argc, argv, trimadapter_opt_str);
     }
-    if(g_args.f1.empty() || g_args.prefix.empty() || g_args.adp_path.empty()){
+
+    if (g_args.f1.empty() || g_args.prefix.empty() || g_args.adp_path.empty()) {
       print_trimadapter_usage();
       return -1;
     }
+
     res = trim_adapter(g_args.f1, g_args.f2, g_args.adp_path, g_args.prefix);
-  } else if(cmd.compare("version") == 0){
+  } else if (cmd.compare("version") == 0) {
     print_version_info();
   } else {
     std::cout << "Unknown command: \"" << cmd  << "\"" << std::endl << std::endl;
     print_usage();
   }
+  
   return res;
 }

--- a/src/parse_gff.cpp
+++ b/src/parse_gff.cpp
@@ -1,183 +1,207 @@
 #include "parse_gff.h"
 
-gff3_feature::gff3_feature(std::string line){
+gff3_feature::gff3_feature(std::string line) {
   int ctr = 0;
+
   std::stringstream line_stream;
   std::string cell;
   line_stream << line;
-  while(std::getline(line_stream,cell,'\t')){
-    switch(ctr){
-    case 0:			// Name
-      this->seqid = cell;
-      break;
-    case 1:
-      this->source = cell;
-      break;
-    case 2:
-      this->type = cell;
-      break;
-    case 3:
-      this->start = atoi(cell.c_str());
-      break;
-    case 4:
-      this->end = atoi(cell.c_str());
-      break;
-    case 5:
-      this->score = atof(cell.c_str());
-      break;
-    case 6:
-      this->strand = cell[0];
-      break;
-    case 7:
-      this->phase = atoi(cell.c_str());
-      break;
-    case 8:
-      this->set_attributes(cell);
-      break;
+
+  while (std::getline(line_stream,cell,'\t')) {
+    switch(ctr) {
+      case 0:			// Name
+        this->seqid = cell;
+        break;
+      case 1:
+        this->source = cell;
+        break;
+      case 2:
+        this->type = cell;
+        break;
+      case 3:
+        this->start = atoi(cell.c_str());
+        break;
+      case 4:
+        this->end = atoi(cell.c_str());
+        break;
+      case 5:
+        this->score = atof(cell.c_str());
+        break;
+      case 6:
+        this->strand = cell[0];
+        break;
+      case 7:
+        this->phase = atoi(cell.c_str());
+        break;
+      case 8:
+        this->set_attributes(cell);
+        break;
     }
+
     ctr++;
   }
-  if(ctr < 9)
+
+  if (ctr < 9)
     std::cout << "GFF file is not in GFF3 file format!" << std::endl;
+
   line_stream.clear();
 }
 
-int gff3_feature::print(){
+int gff3_feature::print() {
   std::cout << seqid << "\t"
-	    << source << "\t"
-    	    << type << "\t"
-    	    << start << "\t"
-	    << end << "\t"
-	    << score << "\t"
-	    << strand << "\t"
-	    << phase << "\t";
+    << source << "\t"
+    << type << "\t"
+    << start << "\t"
+    << end << "\t"
+    << score << "\t"
+    << strand << "\t"
+    << phase << "\t";
+
   std::map<std::string, std::string>::iterator it;
-  for (it = attributes.begin(); it != attributes.end(); it++){
+  for (it = attributes.begin(); it != attributes.end(); it++) {
     std::cout << it->first << ": " << it->second << "; ";
   }
+
   std::cout << std::endl;
+
   return 0;
 }
 
-std::string gff3_feature::get_attribute(std::string key){
+std::string gff3_feature::get_attribute(std::string key) {
   std::string val;
-  if(attributes.find(key) != attributes.end()){
+
+  if (attributes.find(key) != attributes.end()) {
     val = attributes[key];
   }
+
   return val;
 }
 
-int gff3_feature::set_attributes(std::string attr){
+int gff3_feature::set_attributes(std::string attr) {
   std::string key, val;
   std::regex exp("[^;]+");
   std::regex_iterator<std::string::iterator> it(attr.begin(), attr.end(), exp);
   std::regex_iterator<std::string::iterator> rend;
   std::string delimiter = "=";
+
   while (it!=rend) {
     key = it->str().substr(0, it->str().find(delimiter));
     val = it->str().substr(it->str().find(delimiter)+1, it->str().length());
-    if(!key.empty() && !val.empty()){
+
+    if (!key.empty() && !val.empty()) {
       this->attributes[key] = val;
     }
     ++it;
   }
+
   return 0;
 }
 
-uint64_t gff3_feature::get_start(){
+uint64_t gff3_feature::get_start() {
   return start;
 }
 
-uint64_t gff3_feature::get_end(){
+uint64_t gff3_feature::get_end() {
   return end;
 }
 
-int gff3_feature::get_phase(){
+int gff3_feature::get_phase() {
   return phase;
 }
 
-std::string gff3_feature::get_type(){
+std::string gff3_feature::get_type() {
   return type;
 }
 
-int64_t gff3_feature::get_edit_position(){
+int64_t gff3_feature::get_edit_position() {
   int64_t edit_pos = -1;
+
   std::map<std::string, std::string>::iterator it;
-  for (it = attributes.begin(); it != attributes.end(); it++){
-    if(it->first.compare(EDIT_POSITION) == 0){
+  for (it = attributes.begin(); it != attributes.end(); it++) {
+    if (it->first.compare(EDIT_POSITION) == 0) {
       edit_pos = stoi(it->second);
       break;
     }
   }
+
   return edit_pos;
 }
 
-std::string gff3_feature::get_edit_sequence(){
+std::string gff3_feature::get_edit_sequence() {
   std::string edit_seq = "";
+
   std::map<std::string, std::string>::iterator it;
-  for (it = attributes.begin(); it != attributes.end(); it++){
-    if(it->first.compare(EDIT_SEQUENCE) == 0){
+  for (it = attributes.begin(); it != attributes.end(); it++) {
+    if (it->first.compare(EDIT_SEQUENCE) == 0) {
       edit_seq = it->second;
       break;
     }
   }
+
   return edit_seq;
 }
 
-int gff3::print(){
+int gff3::print() {
   std::vector<gff3_feature>::iterator it;
-  for(it = features.begin(); it != features.end(); it++){
+  for (it = features.begin(); it != features.end(); it++) {
     it->print();
   }
+
   return 0;
 }
 
-std::vector<gff3_feature> gff3::get_features(){
+std::vector<gff3_feature> gff3::get_features() {
   return features;
 }
 
-gff3::gff3(){
+gff3::gff3() {
   this->is_empty = true;
 }
 
-gff3::gff3(std::string path){
+gff3::gff3(std::string path) {
   this->is_empty = true;
   this->read_file(path);
 }
 
-int gff3::read_file(std::string path){
+int gff3::read_file(std::string path) {
   std::ifstream fin = std::ifstream(path);
-  if(!fin){
+  if (!fin) {
     std::cout << "GFF file does not exist at " << path << std::endl;
     return -1;
   }
+
   std::string line;
-  while (std::getline(fin, line)){
-    if(line[0] == '#') // Avoid comments in GFF file
+  while (std::getline(fin, line)) {
+    if (line[0] == '#') // Avoid comments in GFF file
       continue;
     features.push_back(gff3_feature(line));
   }
+
   this->is_empty = false;
+
   return 0;
 }
 
-std::vector<gff3_feature> gff3::query_features(uint64_t pos, std::string type){
-  std::vector<gff3_feature>::iterator it;
+std::vector<gff3_feature> gff3::query_features(uint64_t pos, std::string type) {
   std::vector<gff3_feature> res;
-  for(it = features.begin(); it != features.end(); it++){
-    if(it->get_type() != type)
+
+  std::vector<gff3_feature>::iterator it;
+  for (it = features.begin(); it != features.end(); it++) {
+    if (it->get_type() != type)
       continue;
-    if(pos >= it->get_start() && pos <= it->get_end()){
+      
+    if (pos >= it->get_start() && pos <= it->get_end()) {
       res.push_back(*it);
     }
   }
+
   return res;
 }
 
-int gff3::get_count(){
+int gff3::get_count() {
   return features.size();
 }
 
-bool gff3::empty(){
+bool gff3::empty() {
   return is_empty;
 }

--- a/src/primer_bed.cpp
+++ b/src/primer_bed.cpp
@@ -1,14 +1,14 @@
 #include "primer_bed.h"
 
-std::string primer::get_name(){
+std::string primer::get_name() {
   return name;
 }
 
-std::string primer::get_region(){
+std::string primer::get_region() {
   return region;
 }
 
-int primer::get_score(){
+int primer::get_score() {
   return score;
 }
 
@@ -16,275 +16,301 @@ uint32_t primer::get_start() const {
   return start;
 }
 
-uint32_t primer::get_end() const{
+uint32_t primer::get_end() const {
   return end;
 }
 
-char primer::get_strand(){
+char primer::get_strand() {
   return strand;
 }
 
-int primer::get_length(){
+int primer::get_length() {
   return end - start + 1;
 }
 
-int16_t primer::get_pair_indice(){
+int16_t primer::get_pair_indice() {
   return pair_indice;
 }
 
-int16_t primer::get_indice() const{
+int16_t primer::get_indice() const {
   return indice;
 }
 
-uint32_t primer::get_read_count() const{
+uint32_t primer::get_read_count() const {
   return read_count;
 }
 
-void primer::set_start(uint32_t  s){
+void primer::set_start(uint32_t  s) {
   start = s;
 }
 
-void primer::set_end(uint32_t e){
+void primer::set_end(uint32_t e) {
   end = e;
 }
 
-void primer::set_strand(char s){
+void primer::set_strand(char s) {
   strand = s;
 }
 
-void primer::set_region(std::string r){
+void primer::set_region(std::string r) {
   region = r;
 }
 
-void primer::set_name(std::string n){
+void primer::set_name(std::string n) {
   name = n;
 }
 
-void primer::set_score(int s){
+void primer::set_score(int s) {
   score = s;
 }
 
-void primer::set_pair_indice(int16_t i){
+void primer::set_pair_indice(int16_t i) {
   pair_indice = i;
 }
 
-void primer::set_indice(int16_t i){
+void primer::set_indice(int16_t i) {
   indice = i;
 }
 
-void primer::set_read_count(uint32_t rc){
+void primer::set_read_count(uint32_t rc) {
   read_count = rc;
 }
 
-void primer::add_read_count(uint32_t rc){
+void primer::add_read_count(uint32_t rc) {
   read_count += rc;
 }
 
-void print_bed_format(){
+void print_bed_format() {
   std::cout << "iVar uses the standard 6 column BED format as defined here - https://genome.ucsc.edu/FAQ/FAQformat.html#format1." << std::endl;
   std::cout << "It requires the following columns delimited by a tab: chrom, chromStart, chromEnd, name, score, strand" << std::endl;
 }
 
-std::vector<primer> populate_from_file(std::string path, int32_t offset = 0){
+std::vector<primer> populate_from_file(std::string path, int32_t offset = 0) {
   std::ifstream  data(path.c_str());
   std::string line;
   std::vector<primer> primers;
   int16_t indice = 0;
-  while(std::getline(data,line)){ // Remove extra lineStream
+
+  while (std::getline(data,line)) { // Remove extra lineStream
     std::stringstream lineStream(line);
     std::string cell;
     int ctr = 0;
     primer p;
     p.set_strand(0);		// Set strand to NULL
-    while(std::getline(lineStream,cell,'\t')){
-      switch(ctr){
-      case 0:
-	p.set_region(cell);
-	break;
-      case 1:
-	if(std::all_of(cell.begin(), cell.end(), ::isdigit)) {
-	  p.set_start(std::stoul(cell) - offset);
-	} else {
-	  print_bed_format();
-	  primers.clear();
-	  return primers;
-	}
-	break;
-      case 2:
-	if(std::all_of(cell.begin(), cell.end(), ::isdigit)) {
-	  p.set_end(std::stoul(cell) - 1 + offset); // Bed format - End is not 0 based
-	} else {
-	  print_bed_format();
-	  primers.clear();
-	  return primers;
-	}
-	break;
-      case 3:
-	p.set_name(cell);
-	break;
-      case 4:
-	if(std::all_of(cell.begin(), cell.end(), ::isdigit)) {
-	  p.set_score(stoi(cell));
-	} else {
-	  print_bed_format();  // score is missing, send warning but continue populating
-    std::cout << "\nWARNING: The BED file provided did not have the expected score column, but iVar will continue trimming\n" << std::endl;
-    p.set_score(-1);
-	}
-	break;
-      case 5:
-	if(cell[0] == '+' || cell[0] == '-')
-	  p.set_strand(cell[0]);
-	else {
-	  print_bed_format();
-	  primers.clear();
-	  return primers;
-	}
+
+    while (std::getline(lineStream,cell,'\t')) {
+      switch(ctr) {
+        case 0:
+          p.set_region(cell);
+          break;
+        case 1:
+          if (std::all_of(cell.begin(), cell.end(), ::isdigit)) {
+            p.set_start(std::stoul(cell) - offset);
+          } else {
+            print_bed_format();
+            primers.clear();
+            return primers;
+          }
+
+          break;
+        case 2:
+          if (std::all_of(cell.begin(), cell.end(), ::isdigit)) {
+            p.set_end(std::stoul(cell) - 1 + offset); // Bed format - End is not 0 based
+          } else {
+            print_bed_format();
+            primers.clear();
+            return primers;
+          }
+
+          break;
+        case 3:
+          p.set_name(cell);
+          break;
+        case 4:
+          if (std::all_of(cell.begin(), cell.end(), ::isdigit)) {
+            p.set_score(stoi(cell));
+          } else {
+            print_bed_format();  // score is missing, send warning but continue populating
+            std::cout << "\nWARNING: The BED file provided did not have the expected score column, but iVar will continue trimming\n" << std::endl;
+            p.set_score(-1);
+          }
+
+          break;
+        case 5:
+          if (cell[0] == '+' || cell[0] == '-')
+            p.set_strand(cell[0]);
+          else {
+            print_bed_format();
+            primers.clear();
+            return primers;
+          }
       }
+
       ctr++;
     }
-    if(indice == 0 && ctr < 6)
+
+    if (indice == 0 && ctr < 6)
       std::cout << "Strand not found in primer BED file so strand will not be considered for trimming" << std::endl;
+
     p.set_indice(indice);
     p.set_pair_indice(-1);
     p.set_read_count(0);
     primers.push_back(p);
+
     indice++;
   }
+
   std::cout << "Found " << primers.size() << " primers in BED file" << std::endl;
   return primers;
 }
 
-std::vector<primer> populate_from_file(std::string path){
+std::vector<primer> populate_from_file(std::string path) {
   std::ifstream  data(path.c_str());
   std::string line;
   std::vector<primer> primers;
   int16_t indice = 0;
-  while(std::getline(data,line)){ // Remove extra lineStream
+
+  while (std::getline(data,line)) { // Remove extra lineStream
     std::stringstream lineStream(line);
     std::string cell;
     int ctr = 0;
     primer p;
     p.set_strand(0);		// Set strand to NULL
-    while(std::getline(lineStream,cell,'\t')){
-      switch(ctr){
-      case 0:
-	p.set_region(cell);
-	break;
-      case 1:
-	if(std::all_of(cell.begin(), cell.end(), ::isdigit)) {
-	  p.set_start(std::stoul(cell));
-	} else {
-	  print_bed_format();
-	  primers.clear();
-	  return primers;
-	}
-	break;
-      case 2:
-	if(std::all_of(cell.begin(), cell.end(), ::isdigit)) {
-	  p.set_end(std::stoul(cell) - 1); // Bed format - End is not 0 based
-	} else {
-	  print_bed_format();
-	  primers.clear();
-	  return primers;
-	}
-	break;
-      case 3:
-	p.set_name(cell);
-	break;
-      case 4:
-	if(std::all_of(cell.begin(), cell.end(), ::isdigit)) {
-	  p.set_score(stoi(cell));
-	} else {
-	  print_bed_format();  // score is missing, send warning but continue populating
-    std::cout << "\nWARNING: The BED file provided did not have the expected score column, but iVar will continue trimming\n" << std::endl;
-    p.set_score(-1);
-	}
-	break;
-      case 5:
-	if(cell[0] == '+' || cell[0] == '-')
-	  p.set_strand(cell[0]);
-	else {
-	  print_bed_format();
-	  primers.clear();
-	  return primers;
-	}
+
+    while (std::getline(lineStream,cell,'\t')) {
+      switch(ctr) {
+        case 0:
+          p.set_region(cell);
+          break;
+        case 1:
+          if (std::all_of(cell.begin(), cell.end(), ::isdigit)) {
+            p.set_start(std::stoul(cell));
+          } else {
+            print_bed_format();
+            primers.clear();
+            return primers;
+          }
+          
+          break;
+        case 2:
+          if (std::all_of(cell.begin(), cell.end(), ::isdigit)) {
+            p.set_end(std::stoul(cell) - 1); // Bed format - End is not 0 based
+          } else {
+            print_bed_format();
+            primers.clear();
+            return primers;
+          }
+
+          break;
+        case 3:
+          p.set_name(cell);
+          break;
+        case 4:
+          if (std::all_of(cell.begin(), cell.end(), ::isdigit)) {
+            p.set_score(stoi(cell));
+          } else {
+            print_bed_format();  // score is missing, send warning but continue populating
+            std::cout << "\nWARNING: The BED file provided did not have the expected score column, but iVar will continue trimming\n" << std::endl;
+            p.set_score(-1);
+          }
+
+          break;
+        case 5:
+          if (cell[0] == '+' || cell[0] == '-')
+            p.set_strand(cell[0]);
+          else {
+            print_bed_format();
+            primers.clear();
+            return primers;
+          }
       }
       ctr++;
     }
-    if(indice == 0 && ctr < 6)
+
+    if (indice == 0 && ctr < 6)
       std::cout << "Strand not found in primer BED file so strand will not be considered for trimming" << std::endl;
+
     p.set_indice(indice);
     p.set_pair_indice(-1);
     p.set_read_count(0);
     primers.push_back(p);
+
     indice++;
   }
+
   std::cout << "Found " << primers.size() << " primers in BED file" << std::endl;
   return primers;
 }
 
-std::vector<primer> get_primers(std::vector<primer> p, unsigned int pos){
+std::vector<primer> get_primers(std::vector<primer> p, unsigned int pos) {
   std::vector<primer> primers_with_mismatches;
-  for(std::vector<primer>::iterator it = p.begin(); it != p.end(); ++it) {
-    if(it->get_start() <= pos && it->get_end() >= pos){
+  for (std::vector<primer>::iterator it = p.begin(); it != p.end(); ++it) {
+    if (it->get_start() <= pos && it->get_end() >= pos) {
       primers_with_mismatches.push_back(*it);
     }
   }
+
   return primers_with_mismatches;
 }
 
 // Assumes unique primer names in BED file
-int get_primer_indice(std::vector<primer> p, std::string name){
-  for(std::vector<primer>::iterator it = p.begin(); it != p.end(); ++it) {
-    if(it->get_name().compare(name) == 0){
+int get_primer_indice(std::vector<primer> p, std::string name) {
+  for (std::vector<primer>::iterator it = p.begin(); it != p.end(); ++it) {
+    if (it->get_name().compare(name) == 0) {
       return it - p.begin();
     }
   }
+
   return -1;
 }
 
-int populate_pair_indices(std::vector<primer> &primers, std::string path){
+int populate_pair_indices(std::vector<primer> &primers, std::string path) {
   std::ifstream fin(path.c_str());
   std::string line, cell, p1,p2;
   std::stringstream line_stream;
   std::vector<primer>::iterator it;
   int32_t indice;
-  while (std::getline(fin, line)){
+
+  while (std::getline(fin, line)) {
     line_stream << line;
+    
     std::getline(line_stream, cell, '\t');
     p1 = cell;
     line_stream.clear();
+
     std::getline(line_stream, cell, '\t');
     p2 = cell;
     line_stream.clear();
-    if(!p1.empty() && !p2.empty()){
-      for(it = primers.begin(); it != primers.end(); ++it) {
-	if (it->get_name() == p1) {
-	  indice = get_primer_indice(primers, p2);
-	  if (indice != -1)
-	    it->set_pair_indice(indice);
-	  else
-	    std::cout << "Primer pair for " << p1 << " not found in BED file." <<std::endl;
-	} else if (it->get_name() == p2){
-	  indice = get_primer_indice(primers, p1);
-	  if(indice != -1)
-	    it->set_pair_indice(indice);
-	  else
-	    std::cout << "Primer pair for " << p2 << " not found in BED file." << std::endl;
-	}
+
+    if (!p1.empty() && !p2.empty()) {
+      for (it = primers.begin(); it != primers.end(); ++it) {
+        if (it->get_name() == p1) {
+          indice = get_primer_indice(primers, p2);
+          if (indice != -1)
+            it->set_pair_indice(indice);
+          else
+            std::cout << "Primer pair for " << p1 << " not found in BED file." <<std::endl;
+        } else if (it->get_name() == p2) {
+          indice = get_primer_indice(primers, p1);
+          if (indice != -1)
+            it->set_pair_indice(indice);
+          else
+            std::cout << "Primer pair for " << p2 << " not found in BED file." << std::endl;
+        }
       }
     }
   }
+
   return 0;
 }
 
-primer get_min_start(std::vector<primer> primers){
+primer get_min_start(std::vector<primer> primers) {
   std::vector<primer>::iterator it;
   auto minmax_start = std::minmax_element(primers.begin(), primers.end(), [] (primer lhs, primer rhs) {return lhs.get_start() < rhs.get_start();});
   return *(minmax_start.first);
 }
 
-primer get_max_end(std::vector<primer> primers){
+primer get_max_end(std::vector<primer> primers) {
   auto minmax_start = std::minmax_element(primers.begin(), primers.end(), [] (primer lhs, primer rhs) {return lhs.get_end() < rhs.get_end();});
   return *(minmax_start.second);
 }

--- a/src/primer_bed.h
+++ b/src/primer_bed.h
@@ -40,7 +40,7 @@ class primer {
   void set_indice(int16_t i);
   void set_read_count(uint32_t rc);
   void add_read_count(uint32_t rc);
-  bool operator == (const primer& p) const{
+  bool operator == (const primer& p) const {
     return (indice == p.get_indice()) ? true : false;
   }
 

--- a/src/ref_seq.cpp
+++ b/src/ref_seq.cpp
@@ -1,128 +1,159 @@
 #include "ref_seq.h"
 
-char ref_antd::get_base(int64_t pos, std::string region){ // 1-based position
+char ref_antd::get_base(int64_t pos, std::string region) { // 1-based position
   int len;
   char base = 0;
-  if(!region.empty() && this->fai != NULL){
+
+  if (!region.empty() && this->fai != NULL) {
     seq = fai_fetch(this->fai, region.c_str(), &len);
   }
+
   if (seq) base = *(seq + (pos - 1));
+
   free(seq);
+
   return base;
 }
 
-char* ref_antd::get_codon(int64_t pos, std::string region, gff3_feature feature){
+char* ref_antd::get_codon(int64_t pos, std::string region, gff3_feature feature) {
   int len;
   seq = fai_fetch(this->fai, region.c_str(), &len);
+
   int64_t edit_pos = feature.get_edit_position(), codon_start_pos;
   std::string edit_sequence = feature.get_edit_sequence();
+
   int64_t edit_sequence_size = edit_sequence.size();
   char *codon = new char[3];
+
   int i;
   int64_t edit_offset = 0;
-  if(pos > edit_pos + edit_sequence_size && edit_pos != -1){
+
+  if (pos > edit_pos + edit_sequence_size && edit_pos != -1) {
     edit_offset = (pos - edit_pos) > edit_sequence_size ? edit_sequence_size : (pos - edit_pos); // Account for edits in position of insertion
   }
+
   codon_start_pos = (feature.get_start() - 1) + feature.get_phase() + (((pos + edit_offset - (feature.get_start() + feature.get_phase())))/3)*3;
+
   for (i = 0; i < 3; ++i) {
-    if(codon_start_pos +i < (int32_t)feature.get_start() - 1 || codon_start_pos +i > (int32_t)feature.get_end() - 1){ // If before or after CDS region return 'N'.
+    if (codon_start_pos +i < (int32_t)feature.get_start() - 1 || codon_start_pos +i > (int32_t)feature.get_end() - 1) { // If before or after CDS region return 'N'.
       codon[i] = 'N';
-    } else if(codon_start_pos + i < edit_pos - 1 || edit_pos == -1){ // If before edit or with no edit
+    } else if (codon_start_pos + i < edit_pos - 1 || edit_pos == -1) { // If before edit or with no edit
       codon[i] = *(seq + codon_start_pos + i);
-    } else if(codon_start_pos + i >= edit_pos - 1 && codon_start_pos + i <= edit_pos - 1 + edit_sequence_size - 1){ // size() - 1 since edit_pos include one base already
+    } else if (codon_start_pos + i >= edit_pos - 1 && codon_start_pos + i <= edit_pos - 1 + edit_sequence_size - 1) { // size() - 1 since edit_pos include one base already
       codon[i] = edit_sequence[codon_start_pos + i - (edit_pos - 1)];
-    } else if(codon_start_pos + i > edit_pos - 1 + edit_sequence_size - 1) {
+    } else if (codon_start_pos + i > edit_pos - 1 + edit_sequence_size - 1) {
       edit_offset = (codon_start_pos + i) - (edit_pos - 1) > edit_sequence_size ? edit_sequence_size : (codon_start_pos + i) - (edit_pos - 1);
       codon[i] = *(seq + codon_start_pos + i - edit_offset);
     }
   }
+
   free(seq);
+
   return codon;
 }
 
-char* ref_antd::get_codon(int64_t pos, std::string region, gff3_feature feature, char alt){
+char* ref_antd::get_codon(int64_t pos, std::string region, gff3_feature feature, char alt) {
   int len;
   seq = fai_fetch(this->fai, region.c_str(), &len);
+
   int64_t edit_pos = feature.get_edit_position(), codon_start_pos;
   std::string edit_sequence = feature.get_edit_sequence();
+
   int64_t edit_sequence_size = edit_sequence.size();
   char *codon = new char[3];
+
   int i;
   int64_t edit_offset = 0, alt_pos = pos;
-  if(pos > edit_pos + edit_sequence_size && edit_pos != -1){
+
+  if (pos > edit_pos + edit_sequence_size && edit_pos != -1) {
     edit_offset = (pos - edit_pos) > edit_sequence_size ? edit_sequence_size : (pos - edit_pos); // Account for edits in position of insertion
   }
+
   codon_start_pos = (feature.get_start() - 1) + feature.get_phase() + (((pos + edit_offset - (feature.get_start() + feature.get_phase())))/3)*3;
+
   for (i = 0; i < 3; ++i) {
-    if(codon_start_pos + i < edit_pos - 1 || edit_pos == -1){ // If before edit or with no edit
+    if (codon_start_pos + i < edit_pos - 1 || edit_pos == -1) { // If before edit or with no edit
       codon[i] = *(seq + codon_start_pos + i);
-    } else if(codon_start_pos + i >= edit_pos - 1 && codon_start_pos + i <= edit_pos - 1 + edit_sequence_size - 1){ // size() - 1 since edit_pos include one base already
+    } else if (codon_start_pos + i >= edit_pos - 1 && codon_start_pos + i <= edit_pos - 1 + edit_sequence_size - 1) { // size() - 1 since edit_pos include one base already
       codon[i] = edit_sequence[codon_start_pos + i - (edit_pos - 1)];
-    } else if(codon_start_pos + i > edit_pos - 1 + edit_sequence_size - 1) {
+    } else if (codon_start_pos + i > edit_pos - 1 + edit_sequence_size - 1) {
       edit_offset = (codon_start_pos + i) - (edit_pos - 1) > edit_sequence_size ? edit_sequence_size : (codon_start_pos + i) - (edit_pos - 1);
       codon[i] = *(seq + codon_start_pos + i - edit_offset);
     }
   }
+
   // Recompute alt position
   edit_offset = 0;
-  if(alt_pos > edit_pos + edit_sequence_size && edit_pos != -1){
+
+  if (alt_pos > edit_pos + edit_sequence_size && edit_pos != -1) {
     edit_offset = (pos - edit_pos) > edit_sequence_size ? edit_sequence_size : (pos - edit_pos); // Account for edits in position of insertion
   }
+
   alt_pos += edit_offset;
   codon[alt_pos - 1 - codon_start_pos] = alt;
+
   free(seq);
+
   return codon;
 }
 
-int ref_antd::add_gff(std::string path){
+int ref_antd::add_gff(std::string path) {
   // Read GFF file
-  if(!path.empty())
+  if (!path.empty())
     gff.read_file(path);
+
   return 0;
 }
 
-int ref_antd::add_seq(std::string path){
+int ref_antd::add_seq(std::string path) {
   this->fai = NULL;
   // Read reference file
-  if(!path.empty())
+
+  if (!path.empty())
     this->fai = fai_load(path.c_str());
-  if(!this->fai && !path.empty()){
+
+  if (!this->fai && !path.empty()) {
     std::cout << "Reference file does not exist at " << path << std::endl;
     return -1;
   }
+
   return 0;
 }
 
-ref_antd::ref_antd(std::string ref_path){
+ref_antd::ref_antd(std::string ref_path) {
   this->seq = NULL;
   this->add_seq(ref_path);
 }
 
-ref_antd::ref_antd(std::string ref_path, std::string gff_path){
+ref_antd::ref_antd(std::string ref_path, std::string gff_path) {
   this->seq = NULL;
   this->add_seq(ref_path);
   this->add_gff(gff_path);
 }
 
-ref_antd::~ref_antd()
-{
+ref_antd::~ref_antd() {
   if (this->fai) fai_destroy(this->fai);
 }
 
-int ref_antd::codon_aa_stream(std::string region, std::ostringstream &line_stream, std::ofstream &fout, int64_t pos, char alt){
+int ref_antd::codon_aa_stream(std::string region, std::ostringstream &line_stream, std::ofstream &fout, int64_t pos, char alt) {
   std::vector<gff3_feature> features = gff.query_features(pos, "CDS");
-  if(features.size() == 0){	// No matching CDS
+
+  if (features.size() == 0) {	// No matching CDS
     fout << line_stream.str() << "NA\tNA\tNA\tNA\tNA" << std::endl;
     return 0;
   }
+
   std::vector<gff3_feature>::iterator it;
   char *ref_codon, *alt_codon;
-  for(it = features.begin(); it != features.end(); it++){
+
+  for (it = features.begin(); it != features.end(); it++) {
     fout << line_stream.str();
     fout << it->get_attribute("ID") << "\t";
+
     ref_codon = this->get_codon(pos, region, *it);
     fout << ref_codon[0] << ref_codon[1] << ref_codon[2] << "\t";
     fout << codon2aa(ref_codon[0], ref_codon[1], ref_codon[2]) << "\t";
+
     alt_codon = this->get_codon(pos, region, *it, alt);
     fout << alt_codon[0] << alt_codon[1] << alt_codon[2] << "\t";
     fout << codon2aa(alt_codon[0], alt_codon[1], alt_codon[2]);
@@ -131,9 +162,10 @@ int ref_antd::codon_aa_stream(std::string region, std::ostringstream &line_strea
     delete[] ref_codon;
     delete[] alt_codon;
   }
+  
   return 0;
 }
 
-std::vector<gff3_feature> ref_antd::get_gff_features(){
+std::vector<gff3_feature> ref_antd::get_gff_features() {
   return gff.get_features();
 }

--- a/src/remove_reads_from_amplicon.cpp
+++ b/src/remove_reads_from_amplicon.cpp
@@ -1,56 +1,65 @@
 #include "remove_reads_from_amplicon.h"
 
-int rmv_reads_from_amplicon(std::string bam, std::string region_, std::string bam_out, std::vector<std::string> amp, std::string bed, std::string cmd){
+int rmv_reads_from_amplicon (std::string bam, std::string region_, std::string bam_out, std::vector<std::string> amp, std::string bed, std::string cmd) {
   std::vector<primer> primers = populate_from_file(bed);
-  if(primers.size() == 0){
+  if (primers.size() == 0) {
     return 0;
   }
+
   bam_out += ".bam";
   std::cout << "Writing to " << bam_out << std::endl;
-  if(bam.empty()){
+  if (bam.empty()) {
     std::cout << "Bam in empty" << std::endl;
     return 0;
   }
+
   //open BAM for reading
   samFile *in = hts_open(bam.c_str(), "r");
   BGZF *out = bgzf_open(bam_out.c_str(), "w");
-  if(in == NULL) {
+  if (in == NULL) {
     std::cout << ("Unable to open BAM/SAM file.") << std::endl;
     return -1;
   }
+
   //Load the index
   hts_idx_t *idx = sam_index_load(in, bam.c_str());
-  if(idx == NULL) {
-    if(sam_index_build2(bam.c_str(), 0, 0)< 0){
+  if (idx == NULL) {
+    if (sam_index_build2(bam.c_str(), 0, 0)< 0) {
       std::cout << ("Unable to open BAM/SAM index.") << std::endl;
       return -1;
     } else {
       idx = sam_index_load(in, bam.c_str());
     }
   }
+  
   //Get the header
   bam_hdr_t *header = sam_hdr_read(in);
   add_pg_line_to_header(&header, const_cast<char *>(cmd.c_str()));
-  if(bam_hdr_write(out, header) < 0){
+  if (bam_hdr_write(out, header) < 0) {
     std::cout << "Unable to write BAM header to path." << std::endl;
     sam_close(in);
     return -1;
   }
-  if(header == NULL) {
+
+  if (header == NULL) {
     sam_close(in);
     std::cout << "Unable to open BAM/SAM header." << std::endl;
   }
-  if (region_.empty()){
+
+  if (region_.empty()) {
     std::cout << "Number of references: " << header->n_targets << std::endl;
-    for (int i = 0; i < header->n_targets; ++i){
+
+    for (int i = 0; i < header->n_targets; ++i) {
       std::cout << "Reference Name: " << header->target_name[i] << std::endl;
       std::cout << "Reference Length: " << header->target_len[i] << std::endl;
-      if(i==0){
-	region_.assign(header->target_name[i]);
+      if (i==0) {
+        region_.assign(header->target_name[i]);
       }
     }
+
     std::cout << "Using Region: " << region_ << std::endl;
   }
+
   std::string temp(header->text);
   std::string sortFlag ("SO:coordinate");
   if (temp.find(sortFlag)) {
@@ -58,55 +67,67 @@ int rmv_reads_from_amplicon(std::string bam, std::string region_, std::string ba
   } else {
     std::cout << "Not sorted" << std::endl;
   }
+
   //Initialize iterator
   hts_itr_t *iter = NULL;
+
   //Move the iterator to the region we are interested in
   iter  = sam_itr_querys(idx, header, region_.c_str());
-  if(header == NULL || iter == NULL) {
+  if (header == NULL || iter == NULL) {
     sam_close(in);
     std::cout << "Unable to iterate to region within BAM/SAM." << std::endl;
     return -1;
   }
+
   //Initiate the alignment record
   bam1_t *aln = bam_init1();
   int ctr = 0, rmv_ctr = 0;
   bool w;
-  while(sam_itr_next(in, iter, aln) >= 0) {
+
+  while (sam_itr_next(in, iter, aln) >= 0) {
     uint8_t* a = bam_aux_get(aln, "XA");
     w = true;
-    if(a != 0){
-      for(std::vector<std::string>::iterator it = amp.begin(); it != amp.end(); ++it) {
-	if(bam_aux2i(a) == get_primer_indice(primers, *it)){
-	  w = false;
-	}
+
+    if (a != 0) {
+      for (std::vector<std::string>::iterator it = amp.begin(); it != amp.end(); ++it) {
+        if (bam_aux2i(a) == get_primer_indice(primers, *it)) {
+          w = false;
+        }
       }
     }
-    if(w){
-      if(bam_write1(out, aln) < 0){
-	std::cout << "Not able to write to BAM" << std::endl;
-	hts_itr_destroy(iter);
-	hts_idx_destroy(idx);
-	bam_destroy1(aln);
-	bam_hdr_destroy(header);
-	sam_close(in);
-	bgzf_close(out);
-	return -1;
-      };
+
+    if (w) {
+      if (bam_write1(out, aln) < 0) {
+        std::cout << "Not able to write to BAM" << std::endl;
+
+        hts_itr_destroy(iter);
+        hts_idx_destroy(idx);
+        bam_destroy1(aln);
+        bam_hdr_destroy(header);
+        sam_close(in);
+        bgzf_close(out);
+
+        return -1;
+      }
     } else {
       rmv_ctr++;
     }
+
     ctr++;
-    if(ctr % 1000000 == 0){
+    if (ctr % 1000000 == 0) {
       std::cout << "Processed " << ctr << " reads" << std::endl;
     }
   }
+  
   std::cout << "Results:" << std::endl;
   std::cout << rmv_ctr << " reads were removed." << std::endl;
+
   hts_itr_destroy(iter);
   hts_idx_destroy(idx);
   bam_destroy1(aln);
   bam_hdr_destroy(header);
   sam_close(in);
   bgzf_close(out);
+  
   return 0;
 }

--- a/src/suffix_tree.cpp
+++ b/src/suffix_tree.cpp
@@ -6,10 +6,12 @@
 #include "suffix_tree.h"
 #include "alignment.h"
 
-suffix_node::suffix_node(int b, int *e, suffix_node *p, suffix_node *l){
+suffix_node::suffix_node(int b, int *e, suffix_node *p, suffix_node *l) {
   this->children = new suffix_node*[MAX_CHAR];
-  for(unsigned int i = 0; i < MAX_CHAR;i++)
+
+  for (unsigned int i = 0; i < MAX_CHAR;i++)
     this->children[i] = 0;
+
   this->begin = b;
   this->end = e;
   this->nchildren = 0;
@@ -17,331 +19,401 @@ suffix_node::suffix_node(int b, int *e, suffix_node *p, suffix_node *l){
   this->suffix_link =l;
 }
 
-bool suffix_node::is_leaf_node(){
+bool suffix_node::is_leaf_node() {
   return (nchildren == 0);
 }
 
-bool suffix_node::contains_child(int ext){
+bool suffix_node::contains_child(int ext) {
   return !(this->children[ext] == 0);
 }
 
-int suffix_node::get_length(){
-  if(this->end == 0)
+int suffix_node::get_length() {
+  if (this->end == 0)
     return 0;			// For root
+
   return *(this->end) - this->begin + 1;
 }
 
-int suffix_node::get_depth(){
+int suffix_node::get_depth() {
   int ctr = 0;
   suffix_node* n = this;
-  while(n->begin!=-1){
+
+  while (n->begin!=-1) {
     n = n->parent;
     ctr++;
   }
+
   return ctr;
 }
 
-int get_hamming_distance(std::string s1, std::string s2, int k){
+int get_hamming_distance(std::string s1, std::string s2, int k) {
   int n = 0;
-  for(unsigned int i = 0; i < s1.length(); i++){
-    if(s1[i] != s2[i]){
+  for (unsigned int i = 0; i < s1.length(); i++) {
+    if (s1[i] != s2[i]) {
       n++;
     }
-    if(n > k)
+
+    if (n > k)
       return -1;
   }
+
   return n;
 }
 
-std::string suffix_node::get_longest_common_substring(std::string s1, std::string s2){
+std::string suffix_node::get_longest_common_substring(std::string s1, std::string s2) {
   std::string str = s1+"#"+s2+"@";
   std::string p="", tmp, longest_trvsl = "";
   unsigned int max = 0, i;
   suffix_node* node = this;
-  if(node->begin == -1)
+
+  if (node->begin == -1)
     p = "";
-  else{
+  else {
     tmp = node->get_path(str);
-    if(s1.find(p+tmp) != std::string::npos && s2.find(p+tmp) != std::string::npos)
+    if (s1.find(p+tmp) != std::string::npos && s2.find(p+tmp) != std::string::npos)
       p += tmp;
   }
+
   tmp = "";
-  for(i = 0; i < MAX_CHAR;i++){
-    if(node->children[i] == 0)
+
+  for (i = 0; i < MAX_CHAR;i++) {
+    if (node->children[i] == 0)
       continue;
     longest_trvsl = node->children[i]->get_longest_common_substring(s1, s2);
-    if(longest_trvsl.length() > max){
+    if (longest_trvsl.length() > max) {
       max = longest_trvsl.length();
       tmp = longest_trvsl;
     }
   }
+
   p += tmp;
+
   return p;
 }
 
-std::string suffix_node::get_path(std::string s){
-  if(this->begin == -1)
+std::string suffix_node::get_path(std::string s) {
+  if (this->begin == -1)
     return "R";
+
   return s.substr(this->begin, *(this->end) - this->begin + 1);
 }
 
-void suffix_node::extend_path(int *e){
+void suffix_node::extend_path(int *e) {
   this->end = e;
 }
 
-suffix_node* suffix_node::add_child(int ext, int b, int *e, suffix_node* l){
+suffix_node* suffix_node::add_child(int ext, int b, int *e, suffix_node* l) {
   suffix_node *n = new suffix_node(b, e, this, l);
+
   this->children[ext] = n;
   this->nchildren++;
+
   return n;
 }
 
-void suffix_node::add_child(suffix_node* c, int ext){
+void suffix_node::add_child(suffix_node* c, int ext) {
   this->children[ext] = c;
   c->parent = this;
   this->nchildren++;
 }
 
-suffix_node* suffix_node::get_child(int ext){
+suffix_node* suffix_node::get_child(int ext) {
   return this->children[ext];
 }
 
-bool suffix_node::contains_depth(int depth){
+bool suffix_node::contains_depth(int depth) {
   return this->get_depth() <= depth && depth <= (this->get_length() + this->get_depth());
 }
 
-void suffix_node::print(std::string s){
-  for(int i = 0; i < this->get_depth(); i++){
+void suffix_node::print(std::string s) {
+  for (int i = 0; i < this->get_depth(); i++) {
     std::cout << " ";
   }
+
   std::string t = (this->begin == -1) ? "R" : " "+s.substr(this->begin, *(this->end) - this->begin + 1);
   std::cout << t;
-  if(this->suffix_link != 0)
+
+  if (this->suffix_link != 0)
     std::cout << " --- ( " << this->suffix_link->parent->get_path(s) << " " << this->suffix_link->get_path(s) << ")";
-  if(this->begin!=-1)
+
+  if (this->begin!=-1)
     std::cout << " - " << this->parent->get_path(s);
+
   std::cout << std::endl;
-  for(unsigned int i = 0; i<alphabet.length();i++){
-    if(this->children[i]!=0)
+
+  for (unsigned int i = 0; i<alphabet.length();i++) {
+    if (this->children[i]!=0)
       this->children[i]->print(s);
   }
 }
 
-bool suffix_node::walk_next(int &beg, int &suffix_length){
+bool suffix_node::walk_next(int &beg, int &suffix_length) {
   suffix_node *node = this;
-  if(suffix_length >= node->get_length()){
+
+  if (suffix_length >= node->get_length()) {
     beg += node->get_length();
     suffix_length -= node->get_length();
     return true;
   }
+
   return false;
 }
 
-suffix_node* build_suffix_tree(std::string s){
+suffix_node* build_suffix_tree(std::string s) {
   suffix_node *root = new suffix_node(-1,0,0,0);
   root->suffix_link = root;
   root->parent = root;
   suffix_node *cur_node = root, *new_node = 0, *new_cur_node = 0;
+
   int str_ind[MAX_SIZE], suffix_length = 0, *leaf_end=  new int, suffix_count = 0, beg = -1, *end;
   unsigned int i = 0, n_str_ind = 0;
-  for(i = 0; i < s.length();i++){
+
+  for (i = 0; i < s.length();i++) {
     str_ind[i] = alphabet.find(s[i]);
     n_str_ind++;
   }
+
   *leaf_end = 0;
+
   // root->add_child(str_ind[0], 0, leaf_end, root);
-  for(i = 0; i < n_str_ind;i++){
+  for (i = 0; i < n_str_ind;i++) {
     *leaf_end = i;		// Handle Extension Rule 1
     suffix_count++;
     new_node = 0;
-    while(suffix_count > 0){
-      if(suffix_length == 0)
-	beg = i;
-      if(cur_node->children[str_ind[beg]] == 0){	     // Rule 2
-	cur_node->add_child(str_ind[beg], beg, leaf_end, 0); // Trick 3
-	if(new_node != 0){
-	  new_node->suffix_link = cur_node;
-	  new_node = 0;		// No internal node created in Rule 2 here.
-	}
+
+    while (suffix_count > 0) {
+      if (suffix_length == 0)
+        beg = i;
+
+      if (cur_node->children[str_ind[beg]] == 0) {	     // Rule 2
+        cur_node->add_child(str_ind[beg], beg, leaf_end, 0); // Trick 3
+
+        if (new_node != 0) {
+          new_node->suffix_link = cur_node;
+          new_node = 0;		// No internal node created in Rule 2 here.
+        }
       } else {
-	new_cur_node = cur_node->children[str_ind[beg]];
-	if(new_cur_node->walk_next(beg, suffix_length)){
-	  cur_node = new_cur_node;
-	  continue;
-	}
-	if(str_ind[new_cur_node->begin + suffix_length] == str_ind[i]){ // Rule 3
-	  if(new_node != 0 && cur_node->end != 0){
-	    new_node->suffix_link = cur_node;
-	    new_node = 0;		// No internal node created in Rule 2 here.
-	  }
-	  suffix_length++;
-	  break;
-	}
-	// Rule 2 - New internal node created
-	suffix_node *new_int_node;
-	end = new int;
-	*end = new_cur_node->begin + suffix_length - 1;
-	//New internal node
-	new_int_node = cur_node->add_child(str_ind[beg], new_cur_node->begin, end, 0);
-	new_int_node->add_child(str_ind[i], i, leaf_end, 0);
-	new_cur_node->begin += suffix_length;
-	new_int_node->add_child(new_cur_node, str_ind[new_cur_node->begin]);
-	if(new_node != 0)
-	  new_node->suffix_link = new_int_node;
-	new_node = new_int_node;
+        new_cur_node = cur_node->children[str_ind[beg]];
+        if (new_cur_node->walk_next(beg, suffix_length)) {
+          cur_node = new_cur_node;
+          continue;
+        }
+
+        if (str_ind[new_cur_node->begin + suffix_length] == str_ind[i]) { // Rule 3
+          if (new_node != 0 && cur_node->end != 0) {
+            new_node->suffix_link = cur_node;
+            new_node = 0;		// No internal node created in Rule 2 here.
+          }
+          suffix_length++;
+          break;
+        }
+
+        // Rule 2 - New internal node created
+        suffix_node *new_int_node;
+        end = new int;
+        *end = new_cur_node->begin + suffix_length - 1;
+
+        //New internal node
+        new_int_node = cur_node->add_child(str_ind[beg], new_cur_node->begin, end, 0);
+        new_int_node->add_child(str_ind[i], i, leaf_end, 0);
+        new_cur_node->begin += suffix_length;
+        new_int_node->add_child(new_cur_node, str_ind[new_cur_node->begin]);
+
+        if (new_node != 0)
+          new_node->suffix_link = new_int_node;
+
+        new_node = new_int_node;
       }
+
       suffix_count--;
-      if(cur_node->end==0 && suffix_length > 0){
-	suffix_length--;
-	beg = i - suffix_count + 1;
-      } else if(cur_node->end!=0){
-	if(cur_node->suffix_link != 0){
-	  cur_node = cur_node->suffix_link;
-	} else {
-	  cur_node = cur_node->parent->suffix_link;
-	}
-      } else if(cur_node->get_length() == 1){
-	cur_node = root;
+
+      if (cur_node->end==0 && suffix_length > 0) {
+        suffix_length--;
+        beg = i - suffix_count + 1;
+      } else if (cur_node->end!=0) {
+        if (cur_node->suffix_link != 0) {
+          cur_node = cur_node->suffix_link;
+        } else {
+          cur_node = cur_node->parent->suffix_link;
+        }
+      } else if (cur_node->get_length() == 1) {
+        cur_node = root;
       }
     }
   }
+
   return root;
 }
 
-std::string get_reverse_complement(std::string rev_read){
+std::string get_reverse_complement(std::string rev_read) {
   char t = 'N';
-  for(unsigned int i = 0;i< rev_read.length();i++){
-    switch(rev_read[i]){
-    case 'A':
-      t = 'T';
-      break;
-    case 'G':
-      t='C';
-      break;
-    case 'C':
-      t='G';
-      break;
-    case 'T':
-      t='A';
-      break;
+  for (unsigned int i = 0;i< rev_read.length();i++) {
+    switch(rev_read[i]) {
+      case 'A':
+        t = 'T';
+        break;
+      case 'G':
+        t='C';
+        break;
+      case 'C':
+        t='G';
+        break;
+      case 'T':
+        t='A';
+        break;
     }
+
     rev_read[i] = t;
   }
+
   std::reverse(rev_read.begin(), rev_read.end());
+
   return rev_read;
 }
 
-std::vector<std::string> read_adapters_from_fasta(std::string p){
+std::vector<std::string> read_adapters_from_fasta(std::string p) {
   std::vector<std::string> adp;
   std::ifstream fin(p.c_str());
   std::string line;
-  while (std::getline(fin, line)){
-    if(line[0] == '>')
+
+  while (std::getline(fin, line)) {
+    if (line[0] == '>')
       continue;
+
     adp.push_back(line);
   }
+
   return adp;
 }
 
-std::string extend_till_mismatches(std::string cmn, std::string l, std::string adp){
-  if(cmn.length() < MIN_LENGTH){
+std::string extend_till_mismatches(std::string cmn, std::string l, std::string adp) {
+  if (cmn.length() < MIN_LENGTH) {
     return cmn;
   }
+
   int pos = adp.find(cmn);
   int r_pos = l.find(cmn);
-  if(pos == 0)			// Beginning of adapter match
+
+  if (pos == 0)			// Beginning of adapter match
     return cmn;
+
   int k = 0;
   pos--;
   r_pos--;
-  while(r_pos >= 0 && pos >= 0 && k <= MAX_MISMATCHES){
+
+  while (r_pos >= 0 && pos >= 0 && k <= MAX_MISMATCHES) {
     cmn = l[r_pos] + cmn;
-    if(l[r_pos]!=adp[pos])
+
+    if (l[r_pos]!=adp[pos])
       k++;
+
     r_pos--;
     pos--;
   }
+
   return cmn;
 }
 
-int trim_adapter(std::string f1, std::string f2, std::string adp_path, std::string p){
+int trim_adapter(std::string f1, std::string f2, std::string adp_path, std::string p) {
   std::string l1, l2, l1_rc, l2_rc, s, cmn, trmd_read;
+
   int *t = new int[2], beg;
   unsigned int pos;
+
   std::ifstream ff1(f1.c_str()), ff2, pf(p.c_str());
   std::ofstream out((p+".trimmed.fastq").c_str());
+
   std::vector<std::string>::iterator it;
   suffix_node *root = (suffix_node*) malloc(sizeof(suffix_node));
   std::vector<std::string> adp = read_adapters_from_fasta(adp_path);
+
   int i = -1, n = 0, adp_pos;
-  if(!f2.empty()){
+
+  if (!f2.empty()) {
     ff2.open(f2.c_str());
-    while (std::getline(ff1, l1) && std::getline(ff2, l2)){
+
+    while (std::getline(ff1, l1) && std::getline(ff2, l2)) {
       i++;
-      if((i - 1)%4 != 0)
-	continue;
+      if ((i - 1)%4 != 0)
+        continue;
     }
   } else {
-    while (std::getline(ff1, l1)){
+    while (std::getline(ff1, l1)) {
       i++;
-      if((i - 1)%4 != 0){
-	out << l1 << std::endl;
-	continue;
+      if ((i - 1)%4 != 0) {
+        out << l1 << std::endl;
+        continue;
       }
+
       beg = 0;
       pos = l1.length();
       trmd_read = l1;
-      for(it = adp.begin(); it != adp.end(); ++it) {
-	s = l1 + "#" + *it + "@";
-	root = build_suffix_tree(s);
-	cmn = root->get_longest_common_substring(l1, *it);
-	cmn = extend_till_mismatches(cmn, l1, *it);
-	if(cmn.empty()){
-	  l1_rc = get_reverse_complement(l1);
-	  s = l1_rc + "#" + *it + "@";
-	  root = build_suffix_tree(s);
-	  cmn = root->get_longest_common_substring(l1_rc, *it);
-	  cmn = extend_till_mismatches(cmn, l1_rc, *it);
-	  pos = l1_rc.find(cmn);
-	  beg = l1_rc.length() - pos;
-	  adp_pos = (*it).find(cmn);
-	} else {
-	  beg = 0;
-	  pos = l1.find(cmn);
-	  adp_pos = (*it).find(cmn);
-	}
-	if(cmn.length() >= MIN_LENGTH && adp_pos != 0){
-	  beg = 0;
-	  pos = l1.length();
-	  t = align_seqs(l1, *it);
-	  if(*t != -1){
-	    beg = 0;
-	    pos = *(t+1);
-	  } else {
-	    std::cout << "Reverse!" << std::endl;
-	    l1_rc = get_reverse_complement(l1);
-	    t = align_seqs(l1_rc, *it);
-	    if(*t != -1){
-	      pos = l1.length() - *(t+1);
-	      beg = *(t+1);
-	    }
-	  }
-	}
-	std::cout << beg << " " << pos << std::endl;
-	if(beg != 0 || pos != l1.length()){
-	  trmd_read = l1.substr(beg, pos);
-	  n++;
-	  break;
-	}
+
+      for (it = adp.begin(); it != adp.end(); ++it) {
+        s = l1 + "#" + *it + "@";
+        root = build_suffix_tree(s);
+        cmn = root->get_longest_common_substring(l1, *it);
+        cmn = extend_till_mismatches(cmn, l1, *it);
+
+        if (cmn.empty()) {
+          l1_rc = get_reverse_complement(l1);
+          s = l1_rc + "#" + *it + "@";
+          root = build_suffix_tree(s);
+
+          cmn = root->get_longest_common_substring(l1_rc, *it);
+          cmn = extend_till_mismatches(cmn, l1_rc, *it);
+
+          pos = l1_rc.find(cmn);
+          beg = l1_rc.length() - pos;
+
+          adp_pos = (*it).find(cmn);
+        } else {
+          beg = 0;
+          pos = l1.find(cmn);
+          adp_pos = (*it).find(cmn);
+        }
+
+        if (cmn.length() >= MIN_LENGTH && adp_pos != 0) {
+          beg = 0;
+          pos = l1.length();
+          t = align_seqs(l1, *it);
+
+          if (*t != -1) {
+            beg = 0;
+            pos = *(t+1);
+          } else {
+            std::cout << "Reverse!" << std::endl;
+            l1_rc = get_reverse_complement(l1);
+            t = align_seqs(l1_rc, *it);
+
+            if (*t != -1) {
+              pos = l1.length() - *(t+1);
+              beg = *(t+1);
+            }
+          }
+        }
+
+        std::cout << beg << " " << pos << std::endl;
+
+        if (beg != 0 || pos != l1.length()) {
+          trmd_read = l1.substr(beg, pos);
+          n++;
+          break;
+        }
       }
+
       out << trmd_read << std::endl;
     }
   }
+
   std::cout << "Number of Adapter Trimmed: :" << n << std::endl;
+
   delete root;
   delete[] t;
+
   ff1.close();
   ff2.close();
   pf.close();
+  
   return 0;
 }

--- a/src/trim_primer_quality.cpp
+++ b/src/trim_primer_quality.cpp
@@ -2,172 +2,218 @@
 
 #define round_int(x,total) ((int) (0.5 + ((float)x / float(total)) * 10000))/(float)100
 
-int32_t get_pos_on_query(uint32_t *cigar, uint32_t ncigar, int32_t pos, int32_t ref_start){
+int32_t get_pos_on_query(uint32_t *cigar, uint32_t ncigar, int32_t pos, int32_t ref_start) {
   int cig;
   int32_t n;
   int32_t ql = 0, rl = ref_start;
-  for (uint32_t i = 0; i < ncigar; ++i){
+
+  for (uint32_t i = 0; i < ncigar; ++i) {
     cig  = bam_cigar_op(cigar[i]);
     n = bam_cigar_oplen(cigar[i]);
+
     if (bam_cigar_type(cig) & 2) { // Reference consuming
       if (pos <= rl + n) {
-	if (bam_cigar_type(cig) & 1) // Query consuming
-	  ql += (pos - rl);	   // n consumed reference, check if it consumes query too.
-	return ql;
+        if (bam_cigar_type(cig) & 1) // Query consuming
+          ql += (pos - rl);	   // n consumed reference, check if it consumes query too.
+
+        return ql;
       }
+
       rl += n;
     }
+
     if (bam_cigar_type(cig) & 1) // Query consuming
       ql += n;
   }
+
   return ql;
 }
 
 // Number of bases from 3' end for reverse reads
-int32_t get_pos_on_reference(uint32_t *cigar, uint32_t ncigar, uint32_t pos, uint32_t ref_start){
+int32_t get_pos_on_reference(uint32_t *cigar, uint32_t ncigar, uint32_t pos, uint32_t ref_start) {
   int cig;
   int32_t n;
   uint32_t ql = 0, rl = ref_start;
-  for (uint32_t i = 0; i < ncigar; ++i){
+
+  for (uint32_t i = 0; i < ncigar; ++i) {
     cig  = bam_cigar_op(cigar[i]);
     n = bam_cigar_oplen(cigar[i]);
+
     if (bam_cigar_type(cig) & 1) { // Only query consuming
       if (pos <= ql + n) {
-	if (bam_cigar_type(cig) & 2) // Only reference consuming
-	  rl += (pos - ql);	   // n consumed reference, check if it consumes query too.
-	return rl;
+        if (bam_cigar_type(cig) & 2) // Only reference consuming
+          rl += (pos - ql);	   // n consumed reference, check if it consumes query too.
+
+        return rl;
       }
+
       ql += n;
     }
+
     if (bam_cigar_type(cig) & 2) // Only reference consuming
       rl += n;
   }
+
   return rl;
 }
 
-void reverse_qual(uint8_t *q, int l){
-  for (int i = 0; i < l/2; ++i){
+void reverse_qual(uint8_t *q, int l) {
+  for (int i = 0; i < l/2; ++i) {
     q[i]^=q[l-i-1];
     q[l-i-1]^=q[i];
     q[i]^=q[l-i-1];
   }
 }
 
-void reverse_cigar(uint32_t *cigar, int l){
-  for (int i = 0; i < l/2; ++i){
+void reverse_cigar(uint32_t *cigar, int l) {
+  for (int i = 0; i < l/2; ++i) {
     cigar[i]^=cigar[l-i-1];
     cigar[l-i-1]^=cigar[i];
     cigar[i]^=cigar[l-i-1];
   }
 }
 
-double mean_quality(uint8_t *a, int s, int e){
+double mean_quality(uint8_t *a, int s, int e) {
   double m = 0;
-  for (int i = s; i < e; ++i){
+
+  for (int i = s; i < e; ++i) {
     m += (double)a[i];
   }
+
   m = m/(e-s);
+
   return m;
 }
 
-cigar_ quality_trim(bam1_t* r, uint8_t qual_threshold, uint8_t sliding_window){
+cigar_ quality_trim(bam1_t* r, uint8_t qual_threshold, uint8_t sliding_window) {
   bool reverse = false;
+
   uint32_t *ncigar = (uint32_t*) malloc(sizeof(uint32_t) * (r->core.n_cigar + 1)), // Maximum edit is one more element with soft mask
     *cigar = bam_get_cigar(r);
   uint8_t *qual = bam_get_qual(r);
   int32_t start_pos;
-  if(((r->core.flag&BAM_FPAIRED) != 0) && bam_is_rev(r)){
+
+  if (((r->core.flag&BAM_FPAIRED) != 0) && bam_is_rev(r)) {
     reverse = true;
     reverse_qual(qual, r->core.l_qseq);
   }
+
   double m = 60;
   int del_len, cig, temp;
   uint32_t i = 0, j = 0;
+
   cigar_ t;
   init_cigar(&t);
-  if(0 > r->core.l_qseq - sliding_window)
+
+  if (0 > r->core.l_qseq - sliding_window)
     sliding_window = (uint32_t)r->core.l_qseq;
-  while(i < (uint32_t)r->core.l_qseq){
+
+  while (i < (uint32_t)r->core.l_qseq) {
     m = mean_quality(qual, i, i+sliding_window);
-    if(m < qual_threshold)
+
+    if (m < qual_threshold)
       break;
+
     i++;
-    if(i > (uint32_t)r->core.l_qseq - sliding_window)
+
+    if (i > (uint32_t)r->core.l_qseq - sliding_window)
       sliding_window--;
   }
+
   // Reverse qual back.
-  if(reverse){
+  if (reverse) {
     reverse_qual(qual, r->core.l_qseq);
   }
+
   del_len = r->core.l_qseq - i;
   start_pos = get_pos_on_reference(cigar, r->core.n_cigar, del_len, r->core.pos); // For reverse reads need to set core->pos.
-  if(reverse && start_pos <= r->core.pos) {
+
+  if (reverse && start_pos <= r->core.pos) {
     free(ncigar);
+
     t.cigar = cigar;
     t.free_cig = false;
     t.nlength = r->core.n_cigar;
     t.start_pos = r->core.pos;
+
     return t;
   }
+
   int32_t n;
   i = 0;
-  if(reverse){
+
+  if (reverse) {
     reverse_cigar(cigar, r->core.n_cigar);
   }
+
   reverse_cigar(cigar, r->core.n_cigar); // Reverse cigar and trim the beginning of read.
-  while(i < r->core.n_cigar){
-    if (del_len == 0){
+
+  while (i < r->core.n_cigar) {
+    if (del_len == 0) {
       ncigar[j] = cigar[i];
       i++;
       j++;
       continue;
     }
+
     cig  = bam_cigar_op(cigar[i]);
     n = bam_cigar_oplen(cigar[i]);
-    if ((bam_cigar_type(cig) & 1)){ // Consumes Query
-      if(del_len >= n ){
-	ncigar[j] = bam_cigar_gen(n, BAM_CSOFT_CLIP);
-      } else if (del_len < n){
-	ncigar[j] = bam_cigar_gen(del_len, BAM_CSOFT_CLIP);
+
+    if ((bam_cigar_type(cig) & 1)) { // Consumes Query
+      if (del_len >= n ) {
+        ncigar[j] = bam_cigar_gen(n, BAM_CSOFT_CLIP);
+      } else if (del_len < n) {
+        ncigar[j] = bam_cigar_gen(del_len, BAM_CSOFT_CLIP);
       }
+
       j++;
       temp = n;
+
       n = std::max(n - del_len, 0);
       del_len = std::max(del_len - temp, 0);
-      if(n > 0){
-	ncigar[j] = bam_cigar_gen(n, cig);
-	j++;
+
+      if (n > 0) {
+        ncigar[j] = bam_cigar_gen(n, cig);
+        j++;
       }
     }
+
     i++;
   }
+
   reverse_cigar(ncigar, j);	// Reverse Back
-  if(reverse){
+  
+  if (reverse) {
     reverse_cigar(ncigar, j);
   }
+
   t.cigar = ncigar;
   t.nlength = j;
   t.free_cig = true;
   t.start_pos = start_pos;
+
   return t;
 }
 
-void print_cigar(uint32_t *cigar, int nlength){
-  for (int i = 0; i < nlength; ++i){
+void print_cigar(uint32_t *cigar, int nlength) {
+  for (int i = 0; i < nlength; ++i) {
     std::cout << ((cigar[i]) & BAM_CIGAR_MASK);
     std::cout << "-" << ((cigar[i]) >> BAM_CIGAR_SHIFT) << " ";
   }
+
   std::cout << std::endl;
 }
 
-cigar_ primer_trim(bam1_t *r, bool &isize_flag, int32_t new_pos, bool unpaired_rev = false){
+cigar_ primer_trim(bam1_t *r, bool &isize_flag, int32_t new_pos, bool unpaired_rev = false) {
   uint32_t *ncigar = (uint32_t*) malloc(sizeof(uint32_t) * (r->core.n_cigar + 1)), // Maximum edit is one more element with soft mask
     *cigar = bam_get_cigar(r);
+
   uint32_t i = 0, j = 0;
   int max_del_len = 0, cig, temp, del_len = 0;
   bool reverse = false;
-  if((r->core.flag&BAM_FPAIRED) != 0 && isize_flag){ // If paired and isize > read length
-    if (bam_is_rev(r)){ // If -ve strand (?)
+
+  if ((r->core.flag&BAM_FPAIRED) != 0 && isize_flag) { // If paired and isize > read length
+    if (bam_is_rev(r)) { // If -ve strand (?)
       max_del_len = bam_cigar2qlen(r->core.n_cigar, bam_get_cigar(r)) - get_pos_on_query(cigar, r->core.n_cigar, new_pos, r->core.pos) - 1;
       reverse_cigar(cigar, r->core.n_cigar);
       reverse = true;
@@ -175,7 +221,7 @@ cigar_ primer_trim(bam1_t *r, bool &isize_flag, int32_t new_pos, bool unpaired_r
       max_del_len = get_pos_on_query(cigar, r->core.n_cigar, new_pos, r->core.pos);
     }
   } else {			// trim without considering pairing
-    if(unpaired_rev){
+    if (unpaired_rev) {
       max_del_len = bam_cigar2qlen(r->core.n_cigar, bam_get_cigar(r)) - get_pos_on_query(cigar, r->core.n_cigar, new_pos, r->core.pos) - 1;
       reverse_cigar(cigar, r->core.n_cigar);
       reverse = true;
@@ -183,56 +229,74 @@ cigar_ primer_trim(bam1_t *r, bool &isize_flag, int32_t new_pos, bool unpaired_r
       max_del_len = get_pos_on_query(cigar, r->core.n_cigar, new_pos, r->core.pos);
     }
   }
+
   max_del_len = (max_del_len > 0) ? max_del_len : 0; // For cases where reads spans only primer region
   int32_t n, start_pos = 0, ref_add = 0;
+
   bool pos_start = false;
   del_len = max_del_len;
-  while(i < r->core.n_cigar){
-    if (del_len == 0 && pos_start){ // No more bases on query to soft clip
+
+  while (i < r->core.n_cigar) {
+    if (del_len == 0 && pos_start) { // No more bases on query to soft clip
       ncigar[j] = cigar[i];
       i++;
       j++;
       continue;
     }
+
     cig  = bam_cigar_op(cigar[i]);
     n = bam_cigar_oplen(cigar[i]);
-    if(del_len ==0 && (bam_cigar_type(cig) & 1) && (bam_cigar_type(cig) & 2)){ // After soft clipping of query complete, keep incrementing start_pos until first base that consumes both query and ref
+
+    if (del_len ==0 && (bam_cigar_type(cig) & 1) && (bam_cigar_type(cig) & 2)) { // After soft clipping of query complete, keep incrementing start_pos until first base that consumes both query and ref
       pos_start = true;
       continue;
     }
+
     ref_add = n;
-    if ((bam_cigar_type(cig) & 1)){ // Consumes Query
-      if(del_len >= n ){
-	ncigar[j] = bam_cigar_gen(n, BAM_CSOFT_CLIP);
-      } else if (del_len < n && del_len > 0){
-	ncigar[j] = bam_cigar_gen(del_len, BAM_CSOFT_CLIP);
+
+    if ((bam_cigar_type(cig) & 1)) { // Consumes Query
+      if (del_len >= n ) {
+        ncigar[j] = bam_cigar_gen(n, BAM_CSOFT_CLIP);
+      } else if (del_len < n && del_len > 0) {
+        ncigar[j] = bam_cigar_gen(del_len, BAM_CSOFT_CLIP);
       } else if (del_len == 0) {	// Adding insertions before start position of read
-	ncigar[j] = bam_cigar_gen(n, BAM_CSOFT_CLIP);
-	j++;
-	i++;
-	continue;
+        ncigar[j] = bam_cigar_gen(n, BAM_CSOFT_CLIP);
+
+        j++;
+        i++;
+
+        continue;
       }
+
       j++;
+
       ref_add = std::min(del_len, n);
       temp = n;
       n = std::max(n - del_len, 0);
       del_len = std::max(del_len - temp, 0);
-      if(n > 0){
-	ncigar[j] = bam_cigar_gen(n, cig);
-	j++;
+
+      if (n > 0) {
+        ncigar[j] = bam_cigar_gen(n, cig);
+        j++;
       }
-      if(del_len ==0 && (bam_cigar_type(ncigar[j-1]) & 1) && (bam_cigar_type(ncigar[j-1]) & 2)){ // After soft clipping of query complete, keep incrementing start_pos until first base that consumes both query and ref
-      	pos_start = true;
+
+      // After soft clipping of query complete, keep incrementing start_pos until first base that consumes both query and ref
+      if (del_len ==0 && (bam_cigar_type(ncigar[j-1]) & 1) && (bam_cigar_type(ncigar[j-1]) & 2)) { 
+        pos_start = true;
       }
     }
-    if((bam_cigar_type(cig) & 2)) { // Consumes reference but not query
+
+    if ((bam_cigar_type(cig) & 2)) { // Consumes reference but not query
       start_pos += ref_add;
     }
+
     i++;
   }
-  if(reverse){
+
+  if (reverse) {
     reverse_cigar(ncigar, j);
   }
+
   return {
     ncigar,
     true,
@@ -241,66 +305,79 @@ cigar_ primer_trim(bam1_t *r, bool &isize_flag, int32_t new_pos, bool unpaired_r
   };
 }
 
-void replace_cigar(bam1_t *b, uint32_t n, uint32_t *cigar){
+void replace_cigar(bam1_t *b, uint32_t n, uint32_t *cigar) {
   if (n != b->core.n_cigar) {
     int o = b->core.l_qname + b->core.n_cigar * 4;
+
     if (b->l_data + (n - b->core.n_cigar) * 4 > b->m_data) {
       b->m_data = b->l_data + (n - b->core.n_cigar) * 4;
       kroundup32(b->m_data);
       b->data = (uint8_t*)realloc(b->data, b->m_data);
     }
+
     memmove(b->data + b->core.l_qname + n * 4, b->data + o, b->l_data - o);
     memcpy(b->data + b->core.l_qname, cigar, n * 4);
+
     b->l_data += (n - b->core.n_cigar) * 4;
     b->core.n_cigar = n;
   } else memcpy(b->data + b->core.l_qname, cigar, n * 4);
 }
 
 // For paired reads
-void get_overlapping_primers(bam1_t* r, std::vector<primer> primers, std::vector<primer> &overlapped_primers){
+void get_overlapping_primers(bam1_t* r, std::vector<primer> primers, std::vector<primer> &overlapped_primers) {
   overlapped_primers.clear();
+
   uint32_t start_pos = -1;
   char strand = '+';
-  if(bam_is_rev(r)){
+
+  if (bam_is_rev(r)) {
     start_pos = bam_endpos(r)-1;
     strand = '-';
   } else {
     start_pos = r->core.pos;
   }
-  for(std::vector<primer>::iterator it = primers.begin(); it != primers.end(); ++it) {
-    if(start_pos >= it->get_start() && start_pos <= it->get_end() && (strand == it->get_strand() || it->get_strand() == 0))
+
+  for (std::vector<primer>::iterator it = primers.begin(); it != primers.end(); ++it) {
+    if (start_pos >= it->get_start() && start_pos <= it->get_end() && (strand == it->get_strand() || it->get_strand() == 0))
       overlapped_primers.push_back(*it);
   }
 }
 
 // For unpaired reads
-void get_overlapping_primers(bam1_t* r, std::vector<primer> primers, std::vector<primer> &overlapped_primers, bool unpaired_rev){
+void get_overlapping_primers(bam1_t* r, std::vector<primer> primers, std::vector<primer> &overlapped_primers, bool unpaired_rev) {
   overlapped_primers.clear();
+
   uint32_t start_pos = -1;
   char strand = '+';
-  if(unpaired_rev){
+
+  if (unpaired_rev) {
     start_pos = bam_endpos(r) - 1;
     strand = '-';
   } else {
     start_pos = r->core.pos;
   }
-  for(std::vector<primer>::iterator it = primers.begin(); it != primers.end(); ++it) {
-    if(start_pos >= it->get_start() && start_pos <= it->get_end() && (strand == it->get_strand() ||it->get_strand() == 0))
+
+  for (std::vector<primer>::iterator it = primers.begin(); it != primers.end(); ++it) {
+    if (start_pos >= it->get_start() && start_pos <= it->get_end() && (strand == it->get_strand() ||it->get_strand() == 0))
       overlapped_primers.push_back(*it);
   }
 }
 
-void condense_cigar(cigar_ *t){
+void condense_cigar(cigar_ *t) {
   uint32_t i = 0, len = 0, cig, next_cig;
-  while(i< t->nlength -1){
+
+  while (i< t->nlength -1) {
     cig = bam_cigar_op(t->cigar[i]);
     next_cig = bam_cigar_op(t->cigar[i+1]);
-    if(cig == next_cig){
+
+    if (cig == next_cig) {
       len = bam_cigar_oplen(t->cigar[i])+bam_cigar_oplen(t->cigar[i+1]);
       t->cigar[i] = bam_cigar_gen(len, bam_cigar_op(t->cigar[i]));
-      for(uint32_t j = i+1; j < t->nlength - 1; j++){
-	t->cigar[j] = t->cigar[j+1];
+
+      for (uint32_t j = i+1; j < t->nlength - 1; j++) {
+        t->cigar[j] = t->cigar[j+1];
       }
+
       t->nlength--;
     } else {
       i++;
@@ -308,39 +385,46 @@ void condense_cigar(cigar_ *t){
   }
 }
 
-void add_pg_line_to_header(bam_hdr_t** hdr, char *cmd){
+void add_pg_line_to_header(bam_hdr_t** hdr, char *cmd) {
   size_t len = strlen((*hdr)->text) + strlen(cmd)+1;
   char * new_text = (char *)malloc(len);
+
   memcpy(new_text, (*hdr)->text, strlen((*hdr)->text));
+
   new_text[strlen((*hdr)->text)] = '\0';
   strcat(new_text, cmd);
   free((*hdr)->text);
+
   (*hdr)->text = new_text;
   new_text = NULL;
   (*hdr)->l_text = len-1;
 }
 
 // get the length of the longest primer
-int get_bigger_primer(std::vector<primer> primers){
+int get_bigger_primer(std::vector<primer> primers) {
   int max_primer_len = 0;
+
   for (auto & p : primers) {
-    if(max_primer_len < p.get_length()){
+    if (max_primer_len < p.get_length()) {
       max_primer_len = p.get_length();
     }
   }
+
   return max_primer_len;
 }
 
 // check if read is enveloped by any of the amplicons
-bool amplicon_filter(IntervalTree amplicons, bam1_t* r){
+bool amplicon_filter(IntervalTree amplicons, bam1_t* r) {
   Interval fragment_coords = Interval(0, 1);
-  if(r->core.isize > 0){
+
+  if (r->core.isize > 0) {
     fragment_coords.low = r->core.pos;
     fragment_coords.high = r->core.pos + r->core.isize;
   } else {
     fragment_coords.low = bam_endpos(r) + r->core.isize;
     fragment_coords.high = bam_endpos(r);
   }
+
   // debugging
   bool amplicon_flag = amplicons.envelopSearch(fragment_coords);
   return amplicon_flag;
@@ -350,242 +434,320 @@ int trim_bam_qual_primer(std::string bam, std::string bed, std::string bam_out, 
   int retval = 0;
   std::vector<primer> primers;
   int max_primer_len = 0;
-  if(!bed.empty()){
+
+  if (!bed.empty()) {
     primers = populate_from_file(bed, primer_offset);
-    if(primers.size() == 0){
+
+    if (primers.size() == 0) {
       std::cout << "Exiting." << std::endl;
       return -1;
     }
   }
+
   max_primer_len = get_bigger_primer(primers);
+
   // get coordinates of each amplicon
   IntervalTree amplicons;
-  if(!pair_info.empty()){
+
+  if (!pair_info.empty()) {
     amplicons = populate_amplicons(pair_info, primers);
   }
+
   std::cout << "Amplicons detected: " << std::endl;
   amplicons.inOrder();
-  if(bam.empty()){
+
+  if (bam.empty()) {
     std::cout << "Bam file is empty." << std::endl;
     return -1;
   }
+
   bam_out += ".bam";
   samFile *in = hts_open(bam.c_str(), "r");
   BGZF *out = bgzf_open(bam_out.c_str(), "w");
-  if(in == NULL) {
+
+  if (in == NULL) {
     std::cout << ("Unable to open BAM file.") << std::endl;
     return -1;
   }
+
   //Load the index
   hts_idx_t *idx = sam_index_load(in, bam.c_str());
-  if(idx == NULL) {
+  if (idx == NULL) {
     std::cout << "Building BAM index" << std::endl;
-    if(sam_index_build2(bam.c_str(), 0, 0)< 0){
+
+    if (sam_index_build2(bam.c_str(), 0, 0)< 0) {
       std::cout << ("Unable to open or build BAM index.") << std::endl;
       return -1;
     } else {
       idx = sam_index_load(in, bam.c_str());
     }
   }
+
   //Get the header
   bam_hdr_t *header = sam_hdr_read(in);
-  if(header == NULL) {
+  if (header == NULL) {
     sam_close(in);
     std::cout << "Unable to open BAM header." << std::endl;
   }
+
   add_pg_line_to_header(&header, const_cast<char *>(cmd.c_str()));
-  if(bam_hdr_write(out, header) < 0){
+  if (bam_hdr_write(out, header) < 0) {
     std::cout << "Unable to write BAM header to path." << std::endl;
     sam_close(in);
     return -1;
   }
+
   // Get relevant region
   int region_id = -1;
   uint64_t unmapped, mapped, log_skip;
   std::cout << std::endl << "Number of references in file: " << header->n_targets << std::endl;
-  for (int i = 0; i < header->n_targets; ++i){
+
+  for (int i = 0; i < header->n_targets; ++i) {
     std::cout << header->target_name[i] << std::endl;
-    if(region_.compare(std::string(header->target_name[i])) == 0){
+
+    if (region_.compare(std::string(header->target_name[i])) == 0) {
       region_id = i;
     }
-    if(i==0){			// Reading only first reference
+
+    if (i==0) {			// Reading only first reference
       region_.assign(header->target_name[i]);
       region_id = i;
     }
   }
+
   std::cout << "Using Region: " << region_ << std::endl << std::endl;
+
   // Get index stats
   hts_idx_get_stat(idx, region_id, &mapped, &unmapped);
   std::cout << "Found " << mapped << " mapped reads" << std::endl;
   std::cout << "Found " << unmapped << " unmapped reads" << std::endl;
   std::string hdr_text(header->text);
+
   if (hdr_text.find(std::string("SO:coordinate")) != std::string::npos) {
     std::cout << "Sorted By Coordinate" << std::endl; // Sort by coordinate
-  } else if(hdr_text.find(std::string("SO:queryname")) != std::string::npos) {
+  } else if (hdr_text.find(std::string("SO:queryname")) != std::string::npos) {
     std::cout << "Sorted By Query Name" << std::endl; // Sort by name
   } else {
     std::cout << "Not sorted" << std::endl;
   }
+
   std::cout << "-------" << std::endl;
   log_skip = (mapped + unmapped > 10) ? (mapped + unmapped)/10 : 2;
+
   //Initialize iterator
   hts_itr_t *iter = NULL;
+
   //Move the iterator to the region we are interested in
   iter  = sam_itr_querys(idx, header, region_.c_str());
-  if(header == NULL || iter == NULL) {
+
+  if (header == NULL || iter == NULL) {
     sam_close(in);
     std::cout << "Unable to iterate to region within BAM/SAM." << std::endl;
     return -1;
   }
+
   //Initiate the alignment record
   bam1_t *aln = bam_init1();
   int ctr = 0;
+
   cigar_ t;
   init_cigar(&t);
   uint32_t primer_trim_count = 0, no_primer_counter = 0, low_quality = 0;
+
   bool unmapped_flag = false;
   bool amplicon_flag = false;
   bool isize_flag = true;
+
   uint32_t failed_frag_size = 0;
   uint32_t unmapped_counter = 0;
   uint32_t amplicon_flag_ctr = 0;
   primer cand_primer;
+
   std::vector<primer> overlapping_primers;
   std::vector<primer>::iterator cit;
   bool primer_trimmed = false;
+
   //Iterate through reads
-  while(sam_itr_next(in, iter, aln) >= 0) {
+  while (sam_itr_next(in, iter, aln) >= 0) {
     unmapped_flag = false;
     primer_trimmed = false;
     get_overlapping_primers(aln, primers, overlapping_primers);
-    if((aln->core.flag&BAM_FUNMAP) == 0){ // If mapped
+
+    if ((aln->core.flag&BAM_FUNMAP) == 0) { // If mapped
       // if primer pair info provided, check if read correctly overlaps with atleast one amplicon
-      if(!pair_info.empty()){
+      if (!pair_info.empty()) {
         amplicon_flag = amplicon_filter(amplicons, aln);
-        if(!amplicon_flag){
-	  if (keep_for_reanalysis) {   // -k (keep) option
-	    aln->core.flag |= BAM_FQCFAIL;
-	    if (bam_write1(out, aln) < 0) { retval = -1; goto error; }
+        if (!amplicon_flag) {
+          if (keep_for_reanalysis) {   // -k (keep) option
+            aln->core.flag |= BAM_FQCFAIL;
+            if (bam_write1(out, aln) < 0) { retval = -1; goto error; }
           }
+
           amplicon_flag_ctr++;
           continue;
-	}
+        }
       }
+
       isize_flag = (abs(aln->core.isize) - max_primer_len) > abs(aln->core.l_qseq);
+
       // if reverse strand
-      if((aln->core.flag&BAM_FPAIRED) != 0 && isize_flag){ // If paired
-	get_overlapping_primers(aln, primers, overlapping_primers);
-	if(overlapping_primers.size() > 0){ // If read starts before overlapping regions (?)
-	  primer_trimmed = true;
-	  if(bam_is_rev(aln)){	// Reverse read
-	    cand_primer = get_min_start(overlapping_primers); // fetch reverse primer (?)
-	    t = primer_trim(aln, isize_flag, cand_primer.get_start() - 1, false);
-	  } else {		// Forward read
-	    cand_primer = get_max_end(overlapping_primers); // fetch forward primer (?)
-	    t = primer_trim(aln, isize_flag, cand_primer.get_end() + 1, false);
-	    aln->core.pos += t.start_pos;
-	  }
-	  replace_cigar(aln, t.nlength, t.cigar);
-	  free(t.cigar);
-	  // Add count to primer
-	  cit = std::find(primers.begin(), primers.end(), cand_primer);
-	  if(cit != primers.end())
-	    cit->add_read_count(1);
-	}
-	t = quality_trim(aln, min_qual, sliding_window);	// Quality Trimming
-	if(bam_is_rev(aln))  // if reverse strand
-	  aln->core.pos = t.start_pos;
-	condense_cigar(&t);
-	// aln->core.pos += t.start_pos;
-	replace_cigar(aln, t.nlength, t.cigar);
+      if ((aln->core.flag&BAM_FPAIRED) != 0 && isize_flag) { // If paired
+        get_overlapping_primers(aln, primers, overlapping_primers);
+
+        if (overlapping_primers.size() > 0) { // If read starts before overlapping regions (?)
+          primer_trimmed = true;
+
+          if (bam_is_rev(aln)) {	// Reverse read
+            cand_primer = get_min_start(overlapping_primers); // fetch reverse primer (?)
+
+            t = primer_trim(aln, isize_flag, cand_primer.get_start() - 1, false);
+          } else {		// Forward read
+            cand_primer = get_max_end(overlapping_primers); // fetch forward primer (?)
+
+            t = primer_trim(aln, isize_flag, cand_primer.get_end() + 1, false);
+            aln->core.pos += t.start_pos;
+          }
+
+          replace_cigar(aln, t.nlength, t.cigar);
+          free(t.cigar);
+
+          // Add count to primer
+          cit = std::find(primers.begin(), primers.end(), cand_primer);
+
+          if (cit != primers.end())
+            cit->add_read_count(1);
+        }
+
+        t = quality_trim(aln, min_qual, sliding_window);	// Quality Trimming
+
+        if (bam_is_rev(aln))  // if reverse strand
+          aln->core.pos = t.start_pos;
+
+        condense_cigar(&t);
+
+        // aln->core.pos += t.start_pos;
+        replace_cigar(aln, t.nlength, t.cigar);
       } else {			// Unpaired reads: Might be stitched reads
-        if(abs(aln->core.isize) <= abs(aln->core.l_qseq)){
+        if (abs(aln->core.isize) <= abs(aln->core.l_qseq)) {
           failed_frag_size++;
         }
-	// Forward primer
-	get_overlapping_primers(aln, primers, overlapping_primers, false);
-	if(overlapping_primers.size() > 0){
-	  primer_trimmed = true;
-	  cand_primer = get_max_end(overlapping_primers);
-	  t = primer_trim(aln, isize_flag, cand_primer.get_end() + 1, false);
-	  // Update read's left-most coordinate
-	  aln->core.pos += t.start_pos;
-	  replace_cigar(aln, t.nlength, t.cigar);
-	  // Add count to primer
-	  cit = std::find(primers.begin(), primers.end(), cand_primer);
-	  if(cit != primers.end())
-	    cit->add_read_count(1);
-	}
-	// Reverse primer
-	get_overlapping_primers(aln, primers, overlapping_primers, true);
-	if(overlapping_primers.size() > 0){
-	  primer_trimmed = true;
-	  cand_primer = get_min_start(overlapping_primers);
-	  t = primer_trim(aln, isize_flag, cand_primer.get_start() - 1, true);
-	  replace_cigar(aln, t.nlength, t.cigar);
-	  // Add count to primer
-	  cit = std::find(primers.begin(), primers.end(), cand_primer);
-	  if(cit != primers.end())
-	    cit->add_read_count(1);
-	}
-	t = quality_trim(aln, min_qual, sliding_window);	// Quality Trimming
-	if(bam_is_rev(aln))  // if reverse strand
-	  aln->core.pos = t.start_pos;
-	condense_cigar(&t);
-	replace_cigar(aln, t.nlength, t.cigar);
+
+        // Forward primer
+        get_overlapping_primers(aln, primers, overlapping_primers, false);
+        if (overlapping_primers.size() > 0) {
+          primer_trimmed = true;
+          cand_primer = get_max_end(overlapping_primers);
+
+          t = primer_trim(aln, isize_flag, cand_primer.get_end() + 1, false);
+
+          // Update read's left-most coordinate
+          aln->core.pos += t.start_pos;
+          replace_cigar(aln, t.nlength, t.cigar);
+
+          // Add count to primer
+          cit = std::find(primers.begin(), primers.end(), cand_primer);
+          if (cit != primers.end())
+            cit->add_read_count(1);
+        }
+
+        // Reverse primer
+        get_overlapping_primers(aln, primers, overlapping_primers, true);
+        if (overlapping_primers.size() > 0) {
+          primer_trimmed = true;
+          cand_primer = get_min_start(overlapping_primers);
+
+          t = primer_trim(aln, isize_flag, cand_primer.get_start() - 1, true);
+          replace_cigar(aln, t.nlength, t.cigar);
+
+          // Add count to primer
+          cit = std::find(primers.begin(), primers.end(), cand_primer);
+          if (cit != primers.end())
+            cit->add_read_count(1);
+        }
+
+        t = quality_trim(aln, min_qual, sliding_window);	// Quality Trimming
+
+        if (bam_is_rev(aln))  // if reverse strand
+          aln->core.pos = t.start_pos;
+
+        condense_cigar(&t);
+        replace_cigar(aln, t.nlength, t.cigar);
       }
-      if(primer_trimmed){
-	primer_trim_count++;
+
+      if (primer_trimmed) {
+        primer_trim_count++;
       }
     } else {
       unmapped_flag = true;
       unmapped_counter++;
+
       continue;
     }
-    if(bam_cigar2rlen(aln->core.n_cigar, bam_get_cigar(aln)) >= min_length){
-      if(primer_trimmed){	// Write to BAM only if primer found.
-	int16_t cand_ind = cand_primer.get_indice();
-	bam_aux_append(aln, "XA", 's', sizeof(cand_ind), (uint8_t*) &cand_ind);
-	if(bam_write1(out, aln) < 0) { retval = -1; goto error; }
+    if (bam_cigar2rlen(aln->core.n_cigar, bam_get_cigar(aln)) >= min_length) {
+      if (primer_trimmed) {	// Write to BAM only if primer found.
+        int16_t cand_ind = cand_primer.get_indice();
+        bam_aux_append(aln, "XA", 's', sizeof(cand_ind), (uint8_t*) &cand_ind);
+
+        if (bam_write1(out, aln) < 0) {
+          retval = -1;
+          goto error;
+        }
       } else {  // no primer found
         if (keep_for_reanalysis) {   // -k (keep) option
-          if((primers.size() == 0 || !write_no_primer_reads) && !unmapped_flag){ // -k only option
+          if ((primers.size() == 0 || !write_no_primer_reads) && !unmapped_flag) { // -k only option
             aln->core.flag |= BAM_FQCFAIL;
           }
-	  if (bam_write1(out, aln) < 0) { retval = -1; goto error; }
-	} else {        // no -k option
-          if((primers.size() == 0 || write_no_primer_reads) && !unmapped_flag){ // -e only option
-	    if (bam_write1(out, aln) < 0) { retval = -1; goto error; }
+
+          if (bam_write1(out, aln) < 0) {
+            retval = -1;
+            goto error;
+          }
+        } else {        // no -k option
+          if ((primers.size() == 0 || write_no_primer_reads) && !unmapped_flag) { // -e only option
+            if (bam_write1(out, aln) < 0) {
+              retval = -1;
+              goto error;
+            }
           }
         }
-	no_primer_counter++;
+        no_primer_counter++;
       }
     } else {
       low_quality++;
       if (keep_for_reanalysis) {
         aln->core.flag |= BAM_FQCFAIL;
-	if (bam_write1(out, aln) < 0) { retval = -1; goto error; }
+
+        if (bam_write1(out, aln) < 0) {
+          retval = -1;
+          goto error;
+        }
       }
     }
+
     ctr++;
-    if(ctr % log_skip == 0){
+    if (ctr % log_skip == 0) {
       std::cout << "Processed " << (ctr/log_skip) * 10 << "% reads ... " << std::endl;
     }
   }
+
   std::cout << std::endl << "-------" << std::endl;
   std::cout << "Results: " << std::endl;
   std::cout << "Primer Name" << "\t" << "Read Count" << std::endl;
-  for(cit = primers.begin(); cit != primers.end(); ++cit) {
+
+  for (cit = primers.begin(); cit != primers.end(); ++cit) {
     std::cout << cit->get_name() << "\t" << cit->get_read_count() << std::endl;
   }
+
   std::cout << std::endl << "Trimmed primers from " << round_int(primer_trim_count, mapped) << "% (" << primer_trim_count <<  ") of reads." << std::endl;
   std::cout << round_int( low_quality, mapped) << "% (" << low_quality << ") of reads were quality trimmed below the minimum length of " << min_length << " bp and were ";
+
   if (keep_for_reanalysis) {
     std::cout << "marked as failed" << std::endl;
   } else {
     std::cout << "not written to file." << std::endl;
   }
-  if(write_no_primer_reads){
+
+  if (write_no_primer_reads) {
     std::cout << round_int(no_primer_counter, mapped) << "% ("  << no_primer_counter << ")"
               << " of reads started outside of primer regions. Since the "
               << (keep_for_reanalysis ? "-ek flags were " : "-e flag was ")
@@ -596,23 +758,28 @@ int trim_bam_qual_primer(std::string bam, std::string bed, std::string bam_out, 
   } else {
     std::cout << round_int(no_primer_counter, mapped) << "% ("  << no_primer_counter
               << ") of reads that started outside of primer regions were ";
+
     if (keep_for_reanalysis) {
       std::cout << "written to file and marked as failed";
     } else {
       std::cout << "not written to file";
     }
+
     std::cout << std::endl;
   }
-  if(unmapped_counter > 0){
+
+  if (unmapped_counter > 0) {
     std::cout << unmapped_counter << " unmapped reads were not written to file." << std::endl;
   }
-  if(amplicon_flag_ctr > 0){
+
+  if (amplicon_flag_ctr > 0) {
     std::cout << round_int(amplicon_flag_ctr, mapped) 
               << "% (" << amplicon_flag_ctr 
               << ") reads were ignored because they did not fall within an amplicon" 
               << std::endl;
   }
-  if(failed_frag_size > 0){
+
+  if (failed_frag_size > 0) {
     std::cout << round_int(failed_frag_size, mapped)
               << "% (" << failed_frag_size
               << ") of reads had their insert size smaller than their read length"
@@ -621,11 +788,15 @@ int trim_bam_qual_primer(std::string bam, std::string bed, std::string bam_out, 
 
  error:
   if (retval) std::cout << "Not able to write to BAM" << std::endl;
+
   hts_itr_destroy(iter);
   hts_idx_destroy(idx);
+
   bam_destroy1(aln);
   bam_hdr_destroy(header);
+
   sam_close(in);
   bgzf_close(out);
+  
   return retval;
 }

--- a/src/vcf_writer.cpp
+++ b/src/vcf_writer.cpp
@@ -1,8 +1,9 @@
 #include "vcf_writer.h"
 
-int vcf_writer::init_header(){
+int vcf_writer::init_header() {
   this->hdr = bcf_hdr_init("w");
   int res;
+
   res = bcf_hdr_append(hdr,"##ALT=<ID=*,Description=\"Represents allele(s) other than observed.\">");
   res = bcf_hdr_append(hdr,"##INFO=<ID=DP,Number=1,Type=Integer,Description=\"Raw read depth\">");
   res = bcf_hdr_append(hdr, "##INFO=<ID=AD,Number=R,Type=Integer,Description=\"Total read depth for each allele (based on minimum quality threshold)\">");
@@ -13,85 +14,110 @@ int vcf_writer::init_header(){
   res = bcf_hdr_append(hdr, "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">");
   res = bcf_hdr_append(hdr, "##FORMAT=<ID=GQ,Number=1,Type=Integer,Description=\"Genotype Quality\">");
   res = bcf_hdr_append(hdr, "##FILTER=<ID=fobs,Description=\"Fisher's exact test to check if frequency of the iSNV is significantly higher than the mean error rate at that position\">");
+
   bcf_hdr_add_sample(hdr, this->sample_name.c_str());
-  if(res != 0)
+
+  if (res != 0)
     return -1;
+    
   return 0;
 }
 
-int vcf_writer::init(char _mode, std::string fname, std::string region, std::string sample_name, std::string ref_path){
+int vcf_writer::init(char _mode, std::string fname, std::string region, std::string sample_name, std::string ref_path) {
   this->ref = new ref_antd(ref_path);
   this->region = region;
   this->sample_name = sample_name;
+
   std::string mode = "w";
   mode += _mode;
   vcfFile *vcf_file = bcf_open(fname.c_str(), mode.c_str());
+
   this->init_header();
-  if(hdr == NULL || vcf_file == NULL){
+
+  if (hdr == NULL || vcf_file == NULL) {
     std::cout << "Unable to write BCF/VCF file" << std::endl;
     return -1;
   }
-  if(bcf_hdr_write(vcf_file, hdr) < 0){
+
+  if (bcf_hdr_write(vcf_file, hdr) < 0) {
     std::cout << "Unable to write BCF/VCF file" << std::endl;
     return -1;
   }
+
   return 0;
 }
 
-int vcf_writer::write_record(uint32_t pos, std::vector<allele> &alleles, char ref){
+int vcf_writer::write_record(uint32_t pos, std::vector<allele> &alleles, char ref) {
   bcf1_t *rec = bcf_init();
+
   rec->rid  = rec->rid = bcf_hdr_name2id(this->hdr, this->region.c_str());
   rec->pos  = pos;
+
   allele aref = alleles.at(find_ref_in_allele(alleles, ref));
   rec->qual = aref.mean_qual;
-  
 }
 
-int main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
   vcfFile *vcf_file = bcf_open("../data/test.vcf", "w");
   bcf_hdr_t *h = bcf_hdr_init("w");
+
   int res;
-  
-  if(res<0)
+  if (res<0)
     std::cout << "Unable to write BCF header" << std::endl;
+
   // Add sample
   bcf_hdr_add_sample(h, "TEST");
+
   // bcf_hdr_add_sample(h, NULL);
   bcf_hdr_write(vcf_file, h);
+
   // Write record
   bcf1_t *rec = bcf_init();
   rec->rid  = rec->rid = bcf_hdr_name2id(h, "20");
   rec->pos  = 0;
   rec->qual = 20;
+
   // ID
   bcf_update_id(h, rec, "rs6054257");
+
   // INFO
   bcf_update_alleles_str(h, rec, "G,A,TA");
+
   // FILTER
   int32_t tmpi = bcf_hdr_id2int(h, BCF_DT_ID, "PASS");
   bcf_update_filter(h, rec, &tmpi, 1);
+
   // FORMAT
   int32_t *tmpia = (int*)malloc(bcf_hdr_nsamples(h)*2*sizeof(int));
+
   tmpia[0] = bcf_gt_phased(0);
   tmpia[1] = bcf_gt_phased(0);
+
   bcf_update_genotypes(h, rec, &tmpi, bcf_hdr_nsamples(h));
   tmpia[0] = 12;
   tmpia[1] = 4;
+
   bcf_update_format_int32(h, rec, "GQ", tmpia, bcf_hdr_nsamples(h));
   tmpi = 1;
+
   bcf_update_info_int32(h, rec, "NS", &tmpi, 1);
-  if(res < 0)
+
+  if (res < 0)
     std::cout << "Alleles not updated" << std::endl;
+
   int32_t td = 12;
   int32_t ad = 4;
+
   bcf_update_info_int32(h, rec, "DP", &td, 1);
   bcf_update_info_int32(h, rec, "AD", &ad, 1);
+
   std::cout << bcf_hdr_nsamples(h) << std::endl;
   std::cout << rec->n_sample << std::endl;
+
   bcf_write1(vcf_file, h, rec);
   bcf_hdr_destroy(h);
   bcf_close(vcf_file);
+  
   return 0;
 }
 


### PR DESCRIPTION
This PR cleans up the codebase, by applying the following guidelines:

- Code is blocked out into more evenly spaced and logically organized blocks
- Spacing between characters (such as `) {`) is respected
- Keywords will be spaced around relevant symbols (such as `if (`)
- All src files are converted into 2 Spaces instead of tabs (as most files followed this, but some differed)
- Indentation is fixed: one additional indentation per sub-line. Lines will never be moved back to the left.