### PR TITLE
Variant depth issues

### DIFF
--- a/src/allele_functions.cpp
+++ b/src/allele_functions.cpp
@@ -174,8 +174,6 @@ std::vector<allele> update_allele_depth(char ref,std::string bases, std::string 
   }
   if(ad.size() > 0)
     std::sort(ad.begin(), ad.end());
-  //test code
-  print_allele_depths(ad);
   return ad;
 }
 

--- a/src/allele_functions.cpp
+++ b/src/allele_functions.cpp
@@ -174,6 +174,8 @@ std::vector<allele> update_allele_depth(char ref,std::string bases, std::string 
   }
   if(ad.size() > 0)
     std::sort(ad.begin(), ad.end());
+  //test code
+  print_allele_depths(ad);
   return ad;
 }
 

--- a/src/call_consensus_pileup.cpp
+++ b/src/call_consensus_pileup.cpp
@@ -195,8 +195,15 @@ int call_consensus_from_plup(std::istream &cin, std::string seq_id, std::string 
     }
     ret_t t;
     if(mdepth >= min_depth){
+      if(total_bases >= 11286 && total_bases <= 11297){
+      std::cout << "POS " << total_bases << "\n";
       ad = update_allele_depth(ref, bases, qualities, min_qual);
+      std::cout << "\n";
       t = get_consensus_allele(ad, min_qual, threshold, gap, min_insert_threshold);
+      }
+      if(pos > 11297){
+        break;
+      }
       fout << t.nuc;
       tmp_qout << t.q;
     } else{

--- a/src/call_variants.cpp
+++ b/src/call_variants.cpp
@@ -86,7 +86,16 @@ int call_variants_from_plup(std::istream &cin, std::string out_file, uint8_t min
       }
       ctr++;
     }
-    ad = update_allele_depth(ref, bases, qualities, min_qual);
+    //test code
+    if (pos >= 11286 && pos <= 11297){
+      std::cout << "POS " << pos << "\n";
+      ad = update_allele_depth(ref, bases, qualities, min_qual);
+      std::cout << "\n";
+    }
+    if(pos > 11297){
+        break;
+    }
+
     if(ad.size() == 0){
       line_stream.clear();
       continue;

--- a/src/call_variants.cpp
+++ b/src/call_variants.cpp
@@ -86,16 +86,7 @@ int call_variants_from_plup(std::istream &cin, std::string out_file, uint8_t min
       }
       ctr++;
     }
-    //test code
-    if (pos >= 11286 && pos <= 11297){
-      std::cout << "POS " << pos << "\n";
-      ad = update_allele_depth(ref, bases, qualities, min_qual);
-      std::cout << "\n";
-    }
-    if(pos > 11297){
-        break;
-    }
-
+    ad = update_allele_depth(ref, bases, qualities, min_qual);
     if(ad.size() == 0){
       line_stream.clear();
       continue;
@@ -103,8 +94,9 @@ int call_variants_from_plup(std::istream &cin, std::string out_file, uint8_t min
     // Get ungapped depth
     pdepth = 0;
     for(std::vector<allele>::iterator it = ad.begin(); it != ad.end(); ++it) {
-      if(it->nuc[0]=='*' || it->nuc[0] == '+' || it->nuc[0] == '-')
-	continue;
+      //commenting these two lines gets the gapped depth
+      //if(it->nuc[0]=='*' || it->nuc[0] == '+' || it->nuc[0] == '-')
+	//continue;
       pdepth += it->depth;
     }
     if(pdepth < min_depth) {	// Check for minimum depth
@@ -124,9 +116,14 @@ int call_variants_from_plup(std::istream &cin, std::string out_file, uint8_t min
     for(std::vector<allele>::iterator it = ad.begin(); it != ad.end(); ++it) {
       if((*it == *ref_it) || it->nuc[0]=='*')
 	continue;
-      freq_depth = get_frequency_depth(*it, pdepth, mdepth);
+      //use gapped depth if we're looking at insertion or deletion
+      if (it->nuc[0] == '+' || it->nuc[0] == '-'){
+        freq_depth = get_frequency_depth(*it, pdepth, pdepth);
+      }else{
+        freq_depth = get_frequency_depth(*it, pdepth, mdepth);
+      }
       if(freq_depth[0] < min_threshold)
-	continue;
+	continue; 
       out_str << region << "\t";
       out_str << pos << "\t";
       out_str << ref << "\t";


### PR DESCRIPTION
addressing issues #85 and issues #126 
ivar variants currently calculates frequency using ungapped depth, however consensus is called using gapped depths.
for consistency, we now use gapped depths when calling variants.