### PR TITLE
call_consensus_pileup.h: fix build failure with Gcc 12

### DIFF
--- a/src/call_consensus_pileup.h
+++ b/src/call_consensus_pileup.h
@@ -7,6 +7,7 @@
 #include<string>
 #include<regex>
 #include<libgen.h>
+#include<string.h>
 
 #include "allele_functions.h"
 


### PR DESCRIPTION
Since Gcc 12, C string header has been removed from most standard C++
includes.  This causes the following build error, initially reported
in Debian [Bug#1012952]:

	call_consensus_pileup.cpp:138:3: error: ‘strcpy’ was not declared in this scope

Bringing back manually one of `cstring` or `string.h` inside the
header `call_consensus_pileup.h` fixes the issue.

The [original patch] brought in Debian applies to ivar release 1.3.1
to correct the following symptom, but apparently the master branch
diverged from the release, so the `delete[] files` fixing the issue
below may not be needed, but I mention it anyway, just in case this
were to be of interest:

	ivar.cpp:487:14: error: ‘void operator delete(void*)’ called on pointer returned from a mismatched allocation function [-Werror=mismatched-new-delete]
	  487 |       delete files;
	      |              ^~~~~
	ivar.cpp:467:33: note: returned from ‘void* operator new [](std::size_t)’
	  467 |     char **files = new char*[100];
	      |                                 ^

[Bug#1012952]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1012952
[original patch]: https://sources.debian.org/src/ivar/1.3.1%2Bdfsg-5/debian/patches/gcc-12.patch/

Signed-off-by: Étienne Mollier <emollier@debian.org>