### PR TITLE
Fix compilation on newer gcc versions

### DIFF
--- a/src/ivar.cpp
+++ b/src/ivar.cpp
@@ -499,7 +499,7 @@ int main(int argc, char* argv[]){
       for (int i = 0; i < nfiles; ++i) {
 	free(files[i]);
       }
-      free(files);
+      delete[] files;
     } else {
       res = common_variants(g_args.prefix, g_args.min_threshold, argv + optind, argc - optind);
     }


### PR DESCRIPTION
Follow up to https://github.com/andersen-lab/ivar/pull/135#issuecomment-1278491469 - that PR was closed in favor of #136, but they handled different GCC compilation issues. This fixes the last compilation issue, but with a slight tweak to #135 to use `delete[]`.

---

I was able to reproduce the issue and fix by running `docker run --rm -it ubuntu:22.04 bash` and then running the following:
```sh
apt-get update
apt-get install -yq --no-install-recommends automake build-essential ca-certificates libbz2-dev libcurl4-openssl-dev liblzma-dev wget zlib1g-dev

# Install htslib
mkdir -p /tmp/htslib
cd /tmp/htslib
wget https://github.com/samtools/htslib/releases/download/1.16/htslib-1.16.tar.bz2
tar -xjf htslib-1.16.tar.bz2
cd htslib-1.16
make
make install
cd /tmp
rm -rf /tmp/htslib
ldconfig

# Install ivar
mkdir -p /tmp/ivar
cd /tmp/ivar
wget -O ivar.tar.gz https://github.com/andersen-lab/ivar/archive/bafc7b93b195b83caf0a8e8054f49565cb6dee79.tar.gz
tar --strip-components=1 -xf ivar.tar.gz
./autogen.sh
./configure
#####################################################
make # fails
sed -i 's/free(files);/delete[] files;/' src/ivar.cpp
make # succeeds now
#####################################################
```
