### PR TITLE
Issue 147

### DIFF
--- a/src/trim_primer_quality.cpp
+++ b/src/trim_primer_quality.cpp
@@ -386,10 +386,10 @@ void get_overlapping_primers(bam1_t *r, std::vector<primer> primers,
   }
 
   // sort it first
-  std::vector<primer> test = insertionSort(primers, primers.size());
+  //std::vector<primer> test = insertionSort(primers, primers.size());
   // std::cout << test.size() << "\n";
   // then we iterate and push what fits
-  for (std::vector<primer>::iterator it = test.begin(); it != test.end();
+  for (std::vector<primer>::iterator it = primers.begin(); it != primers.end();
        ++it) {
     // if we've passed the end, we're going to find no more matches
     if (start_pos < it->get_start()) {
@@ -596,14 +596,12 @@ int trim_bam_qual_primer(std::string bam, std::string bed, std::string bam_out,
   std::vector<primer> overlapping_primers;
   std::vector<primer>::iterator cit;
   bool primer_trimmed = false;
-  std::string test = "NB552570:188:HL75JAFX3:2:21105:7297:5549";
-
+  std::vector<primer> sorted_primers = insertionSort(primers, primers.size());
   // Iterate through reads
   while (sam_itr_next(in, iter, aln) >= 0) {
     unmapped_flag = false;
     primer_trimmed = false;
-
-    get_overlapping_primers(aln, primers, overlapping_primers);
+    get_overlapping_primers(aln, sorted_primers, overlapping_primers);
 
     if ((aln->core.flag & BAM_FUNMAP) == 0) {  // If mapped
       // if primer pair info provided, check if read correctly overlaps with
@@ -629,7 +627,7 @@ int trim_bam_qual_primer(std::string bam, std::string bed, std::string bam_out,
           (abs(aln->core.isize) - max_primer_len) > abs(aln->core.l_qseq);
       // if reverse strand
       if ((aln->core.flag & BAM_FPAIRED) != 0 && isize_flag) {  // If paired
-        get_overlapping_primers(aln, primers, overlapping_primers);
+        get_overlapping_primers(aln, sorted_primers, overlapping_primers);
         if (overlapping_primers.size() >
             0) {  // If read starts before overlapping regions (?)
           primer_trimmed = true;

--- a/src/trim_primer_quality.h
+++ b/src/trim_primer_quality.h
@@ -64,5 +64,5 @@ void get_overlapping_primers(bam1_t *r, std::vector<primer> primers,
                              bool unpaired_rev);
 int get_bigger_primer(std::vector<primer> primers);
 bool amplicon_filter(IntervalTree amplicons, bam1_t *r);
-
+std::vector<primer> insertionSort(std::vector<primer> primers, uint32_t n);
 #endif

--- a/tests/test_primer_trim.cpp
+++ b/tests/test_primer_trim.cpp
@@ -70,6 +70,7 @@ int main() {
   unsigned int overlapping_primer_sizes[] = {0, 2, 2, 0, 0, 0, 0, 2, 2, 1};
   int ctr = 0;
   std::vector<primer> overlapping_primers;
+  std::vector<primer> sorted_primers = insertionSort(primers, primers.size());     
   primer cand_primer;
   bool isize_flag = false;
   while (sam_itr_next(in, iter, aln) >= 0) {
@@ -79,7 +80,7 @@ int main() {
     isize_flag =
         (abs(aln->core.isize) - max_primer_len) > abs(aln->core.l_qseq);
     std::cout << bam_get_qname(aln) << std::endl;
-    get_overlapping_primers(aln, primers, overlapping_primers);
+    get_overlapping_primers(aln, sorted_primers, overlapping_primers);
     if (overlapping_primers.size() != overlapping_primer_sizes[ctr]) {
       success = -1;
       std::cout << "Overlapping primer sizes for " << bam_get_qname(aln)
@@ -163,6 +164,5 @@ int main() {
   sam_hdr_destroy(header);
   hts_idx_destroy(idx);
   hts_close(in);
-
   return success;
 }


### PR DESCRIPTION
meant to address issue #147 for milestone 1.3.3. currently insertionSort is called many times, leading to a large slowdown in ivar trim. this fix changes the codebase to only call insertionSort one time and updates tests to reflect placement of call outside of get_overlapping_primers.