### PR TITLE
changing type of min_depth from uint8_t to uint32_t

### DIFF
--- a/src/call_consensus_pileup.cpp
+++ b/src/call_consensus_pileup.cpp
@@ -159,7 +159,7 @@ ret_t get_consensus_allele(std::vector<allele> ad, uint8_t min_qual,
 
 int call_consensus_from_plup(std::istream &cin, std::string seq_id,
                              std::string out_file, uint8_t min_qual,
-                             double threshold, uint8_t min_depth, char gap,
+                             double threshold, uint32_t min_depth, char gap,
                              bool min_coverage_flag,
                              double min_insert_threshold) {
   std::string line, cell;
@@ -174,8 +174,8 @@ int call_consensus_from_plup(std::istream &cin, std::string seq_id,
     fout << ">" << seq_id << std::endl;
   }
   delete[] o;
-  int ctr = 0, mdepth = 0;
-  uint32_t prev_pos = 0, pos = 0;
+  int ctr = 0;
+  uint32_t prev_pos = 0, pos = 0, mdepth = 0;
   std::stringstream lineStream;
   char ref;
   std::string bases;

--- a/src/call_consensus_pileup.h
+++ b/src/call_consensus_pileup.h
@@ -23,7 +23,7 @@ struct ret_t {
 void format_alleles(std::vector<allele> &ad);
 int call_consensus_from_plup(std::istream &cin, std::string seq_id,
                              std::string out_file, uint8_t min_qual,
-                             double threshold, uint8_t min_depth, char gap,
+                             double threshold, uint32_t min_depth, char gap,
                              bool min_coverage_flag,
                              double min_insert_threshold);
 ret_t get_consensus_allele(std::vector<allele> ad, uint8_t min_qual,

--- a/src/call_variants.cpp
+++ b/src/call_variants.cpp
@@ -31,7 +31,7 @@ double *get_frequency_depth(
 
 int call_variants_from_plup(std::istream &cin, std::string out_file,
                             uint8_t min_qual, double min_threshold,
-                            uint8_t min_depth, std::string ref_path,
+                            uint32_t min_depth, std::string ref_path,
                             std::string gff_path) {
   std::string line, cell, bases, qualities, region;
   ref_antd refantd(ref_path, gff_path);

--- a/src/call_variants.h
+++ b/src/call_variants.h
@@ -18,7 +18,7 @@
 
 int call_variants_from_plup(std::istream &cin, std::string out_file,
                             uint8_t min_qual, double min_threshold,
-                            uint8_t min_depth, std::string ref_path,
+                            uint32_t min_depth, std::string ref_path,
                             std::string gff_path);
 std::vector<allele>::iterator get_ref_allele(std::vector<allele> &ad, char ref);
 

--- a/src/ivar.cpp
+++ b/src/ivar.cpp
@@ -35,7 +35,7 @@ struct args_t {
   std::string f1;                // -1
   std::string f2;                // -2
   std::string adp_path;          // -a
-  uint8_t min_depth;             // -m
+  uint32_t min_depth;             // -m
   char gap;                      // -n
   bool keep_min_coverage;        // -k
   std::string primer_pair_file;  // -f


### PR DESCRIPTION
changing the type of min_depth from uint8_t to uint32_t to allow depths of > 255 as requested in issue #145