### PR TITLE
Issue 143

### DIFF
--- a/src/ivar.cpp
+++ b/src/ivar.cpp
@@ -292,7 +292,7 @@ int main(int argc, char *argv[]) {
   if (cmd.compare("trim") == 0) {
     g_args.min_qual = 20;
     g_args.sliding_window = 4;
-    g_args.min_length = 30;
+    g_args.min_length = -1;
     g_args.write_no_primers_flag = false;
     g_args.keep_for_reanalysis = false;
     g_args.bed = "";

--- a/src/trim_primer_quality.cpp
+++ b/src/trim_primer_quality.cpp
@@ -485,7 +485,7 @@ int trim_bam_qual_primer(std::string bam, std::string bed, std::string bam_out,
                          std::string region_, uint8_t min_qual,
                          uint8_t sliding_window, std::string cmd,
                          bool write_no_primer_reads, bool keep_for_reanalysis,
-                         int min_length = 30, std::string pair_info = "",
+                         int min_length = -1, std::string pair_info = "",
                          int32_t primer_offset = 0) {
   int retval = 0;
   std::vector<primer> primers;
@@ -598,8 +598,19 @@ int trim_bam_qual_primer(std::string bam, std::string bed, std::string bam_out,
   bool primer_trimmed = false;
   std::string test = "NB552570:188:HL75JAFX3:2:21105:7297:5549";
 
+  bool first_pass = true;
   // Iterate through reads
   while (sam_itr_next(in, iter, aln) >= 0) {
+    // make default min_length default of expected read
+    if(first_pass && min_length == -1){
+      int32_t query_length = aln->core.l_qseq;
+      //std::cout << "query_length " << query_length << std::endl;
+      int32_t percent_query = 0.50 * query_length;
+      //std::cout << "percent_query " << percent_query << std::endl;
+      min_length = percent_query;
+      first_pass = false;
+      std::cout << "Minimum Read Length: " << min_length << std::endl;
+    }
     unmapped_flag = false;
     primer_trimmed = false;
 

--- a/src/trim_primer_quality.cpp
+++ b/src/trim_primer_quality.cpp
@@ -598,19 +598,22 @@ int trim_bam_qual_primer(std::string bam, std::string bed, std::string bam_out,
   bool primer_trimmed = false;
   std::string test = "NB552570:188:HL75JAFX3:2:21105:7297:5549";
 
-  bool first_pass = true;
+  //make default min_length default of expected read length
+  if(min_length == -1){
+    int32_t total_length = 0;
+    int32_t count_reads = 0;
+    while(sam_itr_next(in, iter, aln) >= 0 && count_reads < 1000){
+      count_reads += 1;
+      total_length += aln->core.l_qseq;
+    }
+    int32_t percent_query = 0.50 * (total_length / count_reads);
+    min_length = percent_query;   
+    std::cout << "Minimum Read Length: " << min_length << std::endl; 
+  }
+  //reset the iterator
+  iter = sam_itr_querys(idx, header, region_.c_str());
   // Iterate through reads
   while (sam_itr_next(in, iter, aln) >= 0) {
-    // make default min_length default of expected read
-    if(first_pass && min_length == -1){
-      int32_t query_length = aln->core.l_qseq;
-      //std::cout << "query_length " << query_length << std::endl;
-      int32_t percent_query = 0.50 * query_length;
-      //std::cout << "percent_query " << percent_query << std::endl;
-      min_length = percent_query;
-      first_pass = false;
-      std::cout << "Minimum Read Length: " << min_length << std::endl;
-    }
     unmapped_flag = false;
     primer_trimmed = false;
 


### PR DESCRIPTION
addressing issue #143 by changing the default value of min_length in ivar trim. if no default is set, ivar trim will now use 50% of the initial read length as the min_length parameter.