### PR TITLE
Fix for problem with combined use of stdin and -m parameter

### DIFF
--- a/src/interval_tree.cpp
+++ b/src/interval_tree.cpp
@@ -70,8 +70,8 @@ bool IntervalTree::envelopSearch(ITNode *root, Interval i) {
 void IntervalTree::inOrder(ITNode *root) {
   if (root == NULL) return;
   inOrder(root->left);
-  cout << "[" << root->data->low << ", " << root->data->high << "]"
-       << " max = " << root->max << endl;
+  std::cerr << "[" << root->data->low << ", " << root->data->high << "]"
+            << " max = " << root->max << endl;
   inOrder(root->right);
 }
 

--- a/src/ivar.cpp
+++ b/src/ivar.cpp
@@ -17,7 +17,7 @@
 #include "suffix_tree.h"
 #include "trim_primer_quality.h"
 
-const std::string VERSION = "1.4";
+const std::string VERSION = "1.4.1";
 
 struct args_t {
   std::string bam;               // -i

--- a/src/trim_primer_quality.cpp
+++ b/src/trim_primer_quality.cpp
@@ -529,10 +529,10 @@ bool amplicon_filter(IntervalTree amplicons, bam1_t *r) {
 }
 
 int trim_bam_qual_primer(std::string bam, std::string bed, std::string bam_out,
-                         uint8_t min_qual,
-                         uint8_t sliding_window, std::string cmd,
-                         bool write_no_primer_reads, bool keep_for_reanalysis,
-                         int min_length = -1, std::string pair_info = "",
+                         uint8_t min_qual, uint8_t sliding_window,
+                         std::string cmd, bool write_no_primer_reads,
+                         bool keep_for_reanalysis, int min_length = -1,
+                         std::string pair_info = "",
                          int32_t primer_offset = 0) {
   int retval = 0;
   std::vector<primer> primers;
@@ -609,7 +609,7 @@ int trim_bam_qual_primer(std::string bam, std::string bed, std::string bam_out,
 
   std::vector<bam1_t *> alns;
   std::vector<sam_hdr_t *> headers;
-  
+
   //make default min_length default of expected read length
   if(min_length == -1){
     int32_t total_length = 0;
@@ -623,162 +623,23 @@ int trim_bam_qual_primer(std::string bam, std::string bed, std::string bam_out,
       headers.push_back(header);
     }
     int32_t percent_query = 0.50 * (total_length / count_reads);
-    min_length = percent_query;   
+    min_length = percent_query;
     std::cerr << "Minimum Read Length: " << min_length << std::endl;
   }
-  std::vector<primer> sorted_primers = insertionSort(primers, primers.size()); 
-  // if we already partially iterated, handle those reads first
-  if(alns.size() > 0){
-    for(uint32_t i = 0; i < alns.size(); i++){
-      aln = alns[i];
-      header = headers[i];
-      unmapped_flag = false;
-      primer_trimmed = false;
-      get_overlapping_primers(aln, sorted_primers, overlapping_primers);
+  std::vector<primer> sorted_primers = insertionSort(primers, primers.size());
 
-      if ((aln->core.flag & BAM_FUNMAP) == 0) {  // If mapped
-        // if primer pair info provided, check if read correctly overlaps with
-        // atleast one amplicon
-        if (!pair_info.empty()) {
-          amplicon_flag = amplicon_filter(amplicons, aln);
-          if (!amplicon_flag) {
-            if (keep_for_reanalysis) {  // -k (keep) option
-              aln->core.flag |= BAM_FQCFAIL;
-              if (sam_write1(out, header, aln) < 0) {
-                retval = -1;
-                goto error;
-              }
-            }
-            amplicon_flag_ctr++;
-            continue;
-          }
-        }
-
-        // isize is insert size
-        // l_qseq is the query length
-        isize_flag =
-            (abs(aln->core.isize) - max_primer_len) > abs(aln->core.l_qseq);
-        // if reverse strand
-        if ((aln->core.flag & BAM_FPAIRED) != 0 && isize_flag) {  // If paired
-          get_overlapping_primers(aln, sorted_primers, overlapping_primers);
-          if (overlapping_primers.size() >
-              0) {  // If read starts before overlapping regions (?)
-            primer_trimmed = true;
-            if (bam_is_rev(aln)) {  // Reverse read
-              cand_primer =
-                  get_min_start(overlapping_primers);  // fetch reverse primer (?)
-              t = primer_trim(aln, isize_flag, cand_primer.get_start() - 1,
-                              false);
-
-            } else {  // Forward read
-              cand_primer =
-                  get_max_end(overlapping_primers);  // fetch forward primer (?)
-              t = primer_trim(aln, isize_flag, cand_primer.get_end() + 1, false);
-              aln->core.pos += t.start_pos;
-            }
-            replace_cigar(aln, t.nlength, t.cigar);
-            free(t.cigar);
-            // Add count to primer
-            cit = std::find(primers.begin(), primers.end(), cand_primer);
-            if (cit != primers.end()) cit->add_read_count(1);
-          }
-          t = quality_trim(aln, min_qual, sliding_window);  // Quality Trimming
-          if (bam_is_rev(aln))                              // if reverse strand
-            aln->core.pos = t.start_pos;
-          condense_cigar(&t);
-          // aln->core.pos += t.start_pos;
-          replace_cigar(aln, t.nlength, t.cigar);
-        } else {  // Unpaired reads: Might be stitched reads
-          if (abs(aln->core.isize) <= abs(aln->core.l_qseq)) {
-            failed_frag_size++;
-          }
-
-          // handle the unpaired reads
-          // forward primer unpaired read
-          get_overlapping_primers(aln, primers, overlapping_primers, false);
-          if (overlapping_primers.size() > 0) {
-            primer_trimmed = true;
-            cand_primer = get_max_end(overlapping_primers);
-            t = primer_trim(aln, isize_flag, cand_primer.get_end() + 1, false);
-            // Update read's left-most coordinate
-            aln->core.pos += t.start_pos;
-            replace_cigar(aln, t.nlength, t.cigar);
-            // Add count to primer
-            cit = std::find(primers.begin(), primers.end(), cand_primer);
-            if (cit != primers.end()) cit->add_read_count(1);
-          }
-
-          // reverse primer unpaired read
-          get_overlapping_primers(aln, primers, overlapping_primers, true);
-
-          if (overlapping_primers.size() > 0) {
-            primer_trimmed = true;
-            cand_primer = get_min_start(overlapping_primers);
-            t = primer_trim(aln, isize_flag, cand_primer.get_start() - 1, true);
-            replace_cigar(aln, t.nlength, t.cigar);
-            // Add count to primer
-            cit = std::find(primers.begin(), primers.end(), cand_primer);
-            if (cit != primers.end()) cit->add_read_count(1);
-          }
-          t = quality_trim(aln, min_qual, sliding_window);  // Quality Trimming
-          if (bam_is_rev(aln))                              // if reverse strand
-            aln->core.pos = t.start_pos;
-          condense_cigar(&t);
-          replace_cigar(aln, t.nlength, t.cigar);
-        }  // end handling unpaired reads
-
-        if (primer_trimmed) {
-          primer_trim_count++;
-        }
-      } else {
-        unmapped_flag = true;
-        unmapped_counter++;
-        continue;
-      }
-      if (bam_cigar2rlen(aln->core.n_cigar, bam_get_cigar(aln)) >= min_length) {
-        if (primer_trimmed) {  // Write to BAM only if primer found.
-          int16_t cand_ind = cand_primer.get_indice();
-          bam_aux_append(aln, "XA", 's', sizeof(cand_ind), (uint8_t *)&cand_ind);
-          if (sam_write1(out, header, aln) < 0) {
-            retval = -1;
-            goto error;
-          }
-        } else {                      // no primer found
-          if (keep_for_reanalysis) {  // -k (keep) option
-            if ((primers.size() == 0 || !write_no_primer_reads) &&
-                !unmapped_flag) {  // -k only option
-              aln->core.flag |= BAM_FQCFAIL;
-            }
-            if (sam_write1(out, header, aln) < 0) {
-              retval = -1;
-              goto error;
-            }
-          } else {  // no -k option
-            if ((primers.size() == 0 || write_no_primer_reads) &&
-                !unmapped_flag) {  // -e only option
-              if (sam_write1(out, header, aln) < 0) {
-                retval = -1;
-                goto error;
-              }
-            }
-          }
-          no_primer_counter++;
-        }
-      } else {
-        low_quality++;
-        if (keep_for_reanalysis) {
-          aln->core.flag |= BAM_FQCFAIL;
-          if (sam_write1(out, header, aln) < 0) {
-            retval = -1;
-            goto error;
-          }
-        }
-      }
-      }
-    ctr++;
+  int iterate_reads = 0;
+  std::vector<bam1_t *> aln_itr;
+  if (alns.size() > 0) {
+    aln_itr = alns.begin();
+    aln = (*aln_itr);
+    iterate_reads = 1;
+  } else {
+    iterate_reads = sam_read1(in, header, aln);
   }
+
   // Iterate through reads
-  while(sam_read1(in, header, aln) >= 0) {
+  while (iterate_reads) {
     unmapped_flag = false;
     primer_trimmed = false;
     get_overlapping_primers(aln, sorted_primers, overlapping_primers);
@@ -922,9 +783,17 @@ int trim_bam_qual_primer(std::string bam, std::string bed, std::string bam_out,
       }
     }
     ctr++;
-    if (ctr % 1000000 == 0) { // TODO: Let this be a parameter
-      std::cerr << "Processed " << ctr << " reads ... "
-                << std::endl;
+    if (ctr % 1000000 == 0) {  // TODO: Let this be a parameter
+      std::cerr << "Processed " << ctr << " reads ... " << std::endl;
+    }
+    // Go to next read
+    iterate_reads = 0;
+    aln_itr++;
+    if (aln_itr != alns.end()) {
+      aln = (*aln_itr);
+      iterate_reads = 1;
+    } else {
+      iterate_reads = sam_read1(in, header, aln);
     }
   }
   std::cerr << std::endl << "-------" << std::endl;

--- a/src/trim_primer_quality.cpp
+++ b/src/trim_primer_quality.cpp
@@ -616,6 +616,7 @@ int trim_bam_qual_primer(std::string bam, std::string bed, std::string bam_out,
     int32_t read_itr = 0;
     while(sam_read1(in, header, aln) >= 0 && read_itr < 1000){
       total_length += aln->core.l_qseq;
+      tmp_aln = bam_init1();
       tmp_aln = bam_copy1(tmp_aln, aln);
       alns.push_back(tmp_aln);
       read_itr++;

--- a/src/trim_primer_quality.cpp
+++ b/src/trim_primer_quality.cpp
@@ -629,10 +629,10 @@ int trim_bam_qual_primer(std::string bam, std::string bed, std::string bam_out,
   std::vector<primer> sorted_primers = insertionSort(primers, primers.size());
 
   int iterate_reads = 0;
-  std::vector<bam1_t *> aln_itr;
+  std::vector<bam1_t *>::iterator aln_itr;
   if (alns.size() > 0) {
     aln_itr = alns.begin();
-    aln = (*aln_itr);
+    aln = *aln_itr;
     iterate_reads = 1;
   } else {
     iterate_reads = sam_read1(in, header, aln);
@@ -790,7 +790,7 @@ int trim_bam_qual_primer(std::string bam, std::string bed, std::string bam_out,
     iterate_reads = 0;
     aln_itr++;
     if (aln_itr != alns.end()) {
-      aln = (*aln_itr);
+      aln = *aln_itr;
       iterate_reads = 1;
     } else {
       iterate_reads = sam_read1(in, header, aln);


### PR DESCRIPTION
Addressing issue #157 and adding functionality to save aln objects on first iteration when using the initial reads in a file to calculate the default -m parameter, a bug introduced during release 1.4