### PR TITLE
Update Dockerfile htslib version and ubuntu version 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 MAINTAINER Karthik G <gkarthik@scripps.edu>
 
 RUN apt-get update
 RUN apt-get install -y build-essential autoconf zlib1g-dev python3 wget libbz2-dev liblzma-dev libncurses-dev git bedtools python3-pip vim nano
 # HTSlib
 RUN cd root/ &&\
-    wget https://github.com/samtools/htslib/releases/download/1.9/htslib-1.9.tar.bz2 &&\
-    tar xvf htslib-1.9.tar.bz2 &&\
-    cd htslib-1.9/ &&\
+    wget https://github.com/samtools/htslib/releases/download/1.10.2/htslib-1.10.2.tar.bz2 &&\
+    tar xvf htslib-1.10.2.tar.bz2 &&\
+    cd htslib-1.10.2/ &&\
     ./configure &&\
     make &&\
     make install &&\
     cd ../ &&\
-    rm htslib-1.9.tar.bz2
+    rm htslib-1.10.2.tar.bz2
 ENV LD_LIBRARY_PATH /usr/local/lib:$LD_LIBRARY_PATH
 # SAMtools
 RUN cd root &&\


### PR DESCRIPTION
Updating the current Dockerfile with a new version of htslib (matching the testing suite) and a later version of Ubuntu (20.04) such that the built in version of python is >= 3.7. Addressing issue #165