### PR TITLE
fix build failure with gcc-13

### DIFF
--- a/src/parse_gff.h
+++ b/src/parse_gff.h
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <iterator>

--- a/src/primer_bed.h
+++ b/src/primer_bed.h
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
Attempting to build ivar up to version 1.4.1 with Gcc 13 will result with the following errors:

	primer_bed.h:13:3: error: ‘uint32_t’ does not name a type
	   13 |   uint32_t start;  // 0 based
	      |   ^~~~~~~~
	primer_bed.h:6:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
	    5 | #include <vector>
	  +++ |+#include <cstdint>
	    6 |
	[…]
	parse_gff.h:47:3: error: ‘uint64_t’ does not name a type
	   47 |   uint64_t get_start();
	      |   ^~~~~~~~
	parse_gff.h:6:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
	    5 | #include <regex>
	  +++ |+#include <cstdint>
	    6 | #include <sstream>

Per the hints, this patch will resolve the build problem with the newer compiler version.  This problem has been initially reported in [Debian Bug#1037700].

[Debian Bug#1037700]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1037700