### PR TITLE
Fix `ivar filtervariants` error 

### DIFF
--- a/src/get_common_variants.cpp
+++ b/src/get_common_variants.cpp
@@ -45,6 +45,7 @@ int read_variant_file(
         case 16:  // REF_AA
         case 17:  // ALT_CODON
         case 18:  // ALT_AA
+        case 19:  // POS_AA
           tab_delimited_key += cell + "\t";
           break;
         case 4:

--- a/src/get_common_variants.cpp
+++ b/src/get_common_variants.cpp
@@ -1,11 +1,11 @@
 #include "get_common_variants.h"
 
-const int NUM_FIELDS = 19;
+const int NUM_FIELDS = 20;
 const std::string fields[NUM_FIELDS] = {
     "REGION",    "POS",      "REF",       "ALT",    "REF_DP",
     "REF_RV",    "REF_QUAL", "ALT_DP",    "ALT_RV", "ALT_QUAL",
     "ALT_FREQ",  "TOTAL_DP", "PVAL",      "PASS",   "GFF_FEATURE",
-    "REF_CODON", "REF_AA",   "ALT_CODON", "ALT_AA"};
+    "REF_CODON", "REF_AA",   "ALT_CODON", "ALT_AA", "POS_AA"};
 
 const std::string na_tab_delimited_str =
     "NA\tNA\tNA\tNA\tNA\tNA\tNA\tNA\tNA\tNA";

--- a/src/get_common_variants.cpp
+++ b/src/get_common_variants.cpp
@@ -104,7 +104,7 @@ int common_variants(std::string out, double min_threshold, char *files[],
   for (i = 0; i < 4; ++i) {
     fout << fields[i] << "\t";
   }
-  for (i = 14; i < 19; ++i) {
+  for (i = 14; i < 20; ++i) {
     fout << fields[i] << "\t";
   }
   for (i = 0; i < nfiles; ++i) {


### PR DESCRIPTION
Hi,

This pull request fixes #171 and #178, where `ivar filtervariants` would raise an error because of the extra `POS_AA` column introduced in ivar version 1.3.2.